### PR TITLE
Fixing "save to .tiff" and "save to .txt" buttons

### DIFF
--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -731,12 +731,14 @@ class Fit1D(Atom):
             scaler_v = self.scaler_keys[self.scaler_index-1]
             logger.info('*** Data will be saved with NORMALIZATION from {} ***'.format(scaler_v))
         if to_tiff:
-            output_n = 'output_tiff_' + self.hdf_name.split('.')[0]
+            foldernames = self.hdf_name.split('.')[0]
+            output_n = 'output_tiff_' + foldernames.split('\\')[-1]
             output_data(self.hdf_path, os.path.join(self.result_folder, output_n),
                         norm_name=scaler_v)
             logger.info('Done with saving data {} to tiff files.'.format(output_n))
         else:
-            output_n = 'output_txt_' + self.hdf_name.split('.')[0]
+            foldernames = self.hdf_name.split('.')[0]
+            output_n = 'output_txt_' + foldernames.split('\\')[-1]
             output_data(self.hdf_path, os.path.join(self.result_folder, output_n),
                         file_format='txt', norm_name=scaler_v)
             logger.info('Done with saving data {} to txt files.'.format(output_n))


### PR DESCRIPTION
My name is Matthew Fraund and I'm a graduate student under Dr. Ryan Moffet from the University of the Pacific.  We've had a couple beamtimes at Juergen's XRF beamline and have been using your PyXRF fitting routine and GUI.

Trying to save the individual pixel fitting images to .tiff or .txt files would give the error: Directory name is incorrect "C:\\Users\\Matthew\\Working Directory\\output_txt_C:\\Users\\Matthew\\Working Directory"

I made a small change so that it would access the proper directory.

I'm brand new to python (and GitHub) and made these changes so that the two buttons would work but thought I may as well send the changes to you in case it helped.  The change made everything work as expected.