### PR TITLE
Fix: program crashes when opening a file not in Working Directory (issue 160)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 # Created by .gitignore support plugin (hsz.mobi)
+
 ### Python template
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+
+__enamlcache__/
 
 # C extensions
 *.so
@@ -52,71 +56,17 @@ cover/*
 
 # Sphinx documentation
 docs/_build/
-
-# PyBuilder
-target/
-
-
-
-### Python template
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
-*.egg
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.cache
-nosetests.xml
-coverage.xml
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-
-# vim
-*.swp
-
-# Sphinx documentation
 doc/build/
 doc/source/bluesky.*
 
+doc/source/generated/*.rst
+.pytest_cache
+
 # PyBuilder
 target/
+
+# vim
+*.swp
 
 # PyCharm
 .idea/
@@ -125,7 +75,3 @@ target/
 .ipynb_checkpoints/
 
 .tags
-
-# sphinx
-doc/source/generated/*.rst
-.pytest_cache

--- a/pyxrf/gui.py
+++ b/pyxrf/gui.py
@@ -59,8 +59,12 @@ with enaml.imports():
 def get_defaults():
 
     sub_folder = 'data_analysis'
-    working_directory = os.path.join(os.path.expanduser('~'),
-                                     sub_folder)
+    working_directory = os.path.join(os.path.expanduser('~'), sub_folder)
+    # Ideally, if directory does not exist, it should be created, but for now
+    #     we just set working directory to user directory
+    if not os.path.exists(working_directory):
+        working_directory = os.path.expanduser('~')
+                                    
     output_directory = working_directory
     default_parameters = param_data
     defaults = {'working_directory': working_directory,

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -126,7 +126,6 @@ class FileIOModel(Atom):
         self.file_channel_list = []
         logger.info('File is loaded: %s' % (self.file_name))
 
-        print(f"wd: {self.working_directory}  fn: {self.file_name}")
 
         # focus on single file only
         self.img_dict, self.data_sets = file_handler(self.working_directory,

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -126,6 +126,8 @@ class FileIOModel(Atom):
         self.file_channel_list = []
         logger.info('File is loaded: %s' % (self.file_name))
 
+        print(f"wd: {self.working_directory}  fn: {self.file_name}")
+
         # focus on single file only
         self.img_dict, self.data_sets = file_handler(self.working_directory,
                                                      self.file_name,

--- a/pyxrf/view/fileio.enaml
+++ b/pyxrf/view/fileio.enaml
@@ -44,6 +44,8 @@ from enaml.core.api import Include, Looper
 from enaml.layout.geometry import Box
 from enaml.stdlib.fields import FloatField
 from enaml.stdlib.fields import IntField as DefaultIntField
+from enaml.stdlib.dialog_buttons import DialogButton
+from enaml.stdlib.message_box import MessageBox, critical
 import os
 import numpy as np
 from ..model.fileio import sep_v
@@ -90,11 +92,12 @@ enamldef FileView(DockItem): file_view:
             PushButton: folder_btn:
                 text = "Working Directory"
                 clicked ::
-                    path = FileDialogEx.get_existing_directory(file_view)
+                    path = FileDialogEx.get_existing_directory(file_view, current_path=io_model.working_directory)
                     if path:
                         io_model.working_directory = path
             Field: folder_fd:
                 text := io_model.working_directory
+                read_only = True
                 #maximum_size = 400
 
             CheckBox: cb_each:
@@ -104,19 +107,35 @@ enamldef FileView(DockItem): file_view:
             PushButton: files_btn:
                 text = "Load Data File"
                 clicked ::
-                    path = FileDialogEx.get_open_file_names(file_view, current_path=io_model.working_directory)
+                    path = FileDialogEx.get_open_file_names(file_view, 
+                                                            file_mode="existing_files", 
+                                                            name_filters=["*.h5", "*"],
+                                                            selected_name_filter="*.h5",
+                                                            current_path=io_model.working_directory)
                     if path:
                         # only load one file
                         # 'temp' is used to reload the same file, otherwise file_name will not update
                         io_model.file_name = 'temp'
-                        io_model.file_name = [item.split(sep_v)[-1] for item in path][0:1][0]
-                        files_load.text = '{} is loaded.'.format(io_model.file_name)
+                        f_dir, f_name = os.path.split(path[0])  # Open only the first of the selected files 
+                        io_model.working_directory = f_dir
+                        try: 
+                            io_model.file_name = f_name
+                        except:
+                            btns = [DialogButton('Ok', 'accept')]
+                            # 'critical' shows MessageBox
+                            critical(self, 'ERROR', f'Incorrect format of input file "{path[0]}": PyXRF accepts only custom HDF (.h5) files.', btns)
+                        else:    
+                            files_load.text = '{} is loaded.'.format(io_model.file_name)
 
-                        plot_model.parameters = param_model.param_new
-                        setting_model.parameters = param_model.param_new
-                        setting_model.data_sets = io_model.data_sets
-                        fit_model.data_sets = io_model.data_sets
-                        fit_model.fit_img = {} # clear dict in fitmodel to rm old results
+                            # Disable the button which calls Working Directory dialog. Changing working directory at this point
+                            #     will most likely make the program crash at some point
+                            folder_btn.enabled = False
+
+                            plot_model.parameters = param_model.param_new
+                            setting_model.parameters = param_model.param_new
+                            setting_model.data_sets = io_model.data_sets
+                            fit_model.data_sets = io_model.data_sets
+                            fit_model.fit_img = {} # clear dict in fitmodel to rm old results
 
             Label: files_load:
                 text = 'No data is loaded.'


### PR DESCRIPTION
The issue is fixed. Now Working Directory is set to the directory where input file is located. Once the input file is first opened, the button is disabled and Working Directory can not be changed manually, therefore the behavior of the program remains consistent (```working_directory``` and ```file_name``` track the location of the input file until the new file is selected). 

Two other changes:
-  File mask (*.h5) is added to the Open File dialog box, so that only .h5 files are displayed by default. '*' mask can also be selected if needed.
- MessageBox is added for reporting errors while reading data file. Before this change the program would crash if input file had incorrect format. 