### PR TITLE
Fill incident energy

### DIFF
--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -269,6 +269,8 @@ class GuessParamModel(Atom):
     auto_fit_all = Dict()
     bound_val = Float(1.0)
 
+    energy_bound_high_buf = Float(5.0)
+
     def __init__(self, **kwargs):
         try:
             # default parameter is the original parameter, for user to restore
@@ -281,6 +283,9 @@ class GuessParamModel(Atom):
         self.pileup_data = {'element1': 'Si_K',
                             'element2': 'Si_K',
                             'intensity': 0.0}
+
+        # The following line is part of the fix for automated updating of the energy bound in 'Automatic Element Finding' dialog box
+        self.energy_bound_high_buf = self.param_new['non_fitting_values']['energy_bound_high']['value']
 
     def default_param_update(self, change):
         """
@@ -296,6 +301,16 @@ class GuessParamModel(Atom):
         self.default_parameters = change['value']
         self.param_new = copy.deepcopy(self.default_parameters)
         self.element_list = get_element(self.param_new)
+
+        # The following line is part of the fix for automated updating of the energy bound in 'Automatic Element Finding' dialog box
+        self.energy_bound_high_buf = self.param_new['non_fitting_values']['energy_bound_high']['value']
+
+
+    # The following function is part of the fix for automated updating of the energy bound in 'Automatic Element Finding' dialog box
+    @observe('energy_bound_high_buf')
+    def _update_energy_bound_high_buf(self, change):
+        self.param_new['non_fitting_values']['energy_bound_high']['value'] = change['value']  
+
 
     def param_from_db_update(self, change):
         self.default_parameters = change['value']

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -269,7 +269,7 @@ class GuessParamModel(Atom):
     auto_fit_all = Dict()
     bound_val = Float(1.0)
 
-    energy_bound_high_buf = Float(5.0)
+    energy_bound_high_buf = Float(0.0)
 
     def __init__(self, **kwargs):
         try:
@@ -305,12 +305,10 @@ class GuessParamModel(Atom):
         # The following line is part of the fix for automated updating of the energy bound in 'Automatic Element Finding' dialog box
         self.energy_bound_high_buf = self.param_new['non_fitting_values']['energy_bound_high']['value']
 
-
     # The following function is part of the fix for automated updating of the energy bound in 'Automatic Element Finding' dialog box
     @observe('energy_bound_high_buf')
     def _update_energy_bound_high_buf(self, change):
         self.param_new['non_fitting_values']['energy_bound_high']['value'] = change['value']  
-
 
     def param_from_db_update(self, change):
         self.default_parameters = change['value']

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -136,7 +136,7 @@ class LinePlotModel(Atom):
 
     plot_type = List()
     max_v = Float()
-    incident_energy = Float(30.0)
+    incident_energy = Float(12.0)
 
     eline_obj = List()
 

--- a/pyxrf/model/param_data.py
+++ b/pyxrf/model/param_data.py
@@ -27,7 +27,7 @@ param_data = {
         "linear": "fixed",
         "max": 13.0,
         "min": 9.0,
-        "default": 10.0,
+        "default": 12.0,
         "value": 12.0
     },
     "compton_amplitude": {
@@ -226,12 +226,12 @@ param_data = {
     "non_fitting_values": {
         "element_list": "Al_K, S_K, Cl_K, Ar_K, Ca_K, Cr_K, Fe_K, Co_K, Ni_K, Cu_K, Pm_L, Gd_L",
         "energy_bound_high": {
-            "default_value": 13.5,
+            "default_value": 12.8,
             "description": "E high [keV]",
             "value": 12.8
         },
         "energy_bound_low": {
-            "default_value": 1.5,
+            "default_value": 1.0,
             "description": "E low [keV]",
             "value": 1.0
         },

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -850,7 +850,6 @@ enamldef AutoFindElements(Window): auto_win:
 
             Looper: 
                 iterable << [param_model.param_new['non_fitting_values'][k] for k in ('energy_bound_high',)]
-                #iiterable << sorted_param(param_model)
                 Label:
                     text = loop_item['description']
                     maximum_size = 140
@@ -868,7 +867,6 @@ enamldef AutoFindElements(Window): auto_win:
 
             Looper: 
                 iterable << [param_model.param_new['non_fitting_values'][k] for k in ('energy_bound_low',)]
-                #iterable << [param_model.param_new['non_fitting_values'][k] for k in sorted(list(param_model.param_new['non_fitting_values'].keys()))]
                 Label:
                     text = loop_item['description']
                     maximum_size = 140

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -871,7 +871,6 @@ enamldef AutoFindElements(Window): auto_win:
             Looper: 
                 iterable << [param_model.param_new['non_fitting_values'][k] for k in ('energy_bound_low',)]
                 #iterable << [param_model.param_new['non_fitting_values'][k] for k in sorted(list(param_model.param_new['non_fitting_values'].keys()))]
-                #iiterable << sorted_param(param_model)
                 Label:
                     text = loop_item['description']
                     maximum_size = 140

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -850,7 +850,6 @@ enamldef AutoFindElements(Window): auto_win:
 
             Looper: 
                 iterable << [param_model.param_new['non_fitting_values'][k] for k in ('energy_bound_high',)]
-                #iterable << [param_model.param_new['non_fitting_values'][k] for k in sorted(list(param_model.param_new['non_fitting_values'].keys()))]
                 #iiterable << sorted_param(param_model)
                 Label:
                     text = loop_item['description']

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -835,6 +835,12 @@ enamldef AutoFindElements(Window): auto_win:
                     constraints = [hbox(ff, pb_value_default)]
                     FloatField: ff:
                         value := param_model.param_new[loop_item]['value']
+                        value ::
+                            if loop_item == 'coherent_sct_energy':
+                                v = round((value + 0.8)*100.0)/100.0  # Add 0.8 to float in a reliable way
+                                plot_model.incident_energy = value  # Just copy the selected value of incident energy
+                                param_model.param_new['non_fitting_values']['energy_bound_high']['value'] = v
+                                param_model.energy_bound_high_buf = v
                         maximum_size = 160
                     PushButton: pb_value_default:
                         text = 'Default'
@@ -842,8 +848,28 @@ enamldef AutoFindElements(Window): auto_win:
                         clicked ::
                             ff.value = param_model.param_new[loop_item]['default']
 
-            Looper:
-                iterable << [param_model.param_new['non_fitting_values'][k] for k in ('energy_bound_high', 'energy_bound_low')]
+            Looper: 
+                iterable << [param_model.param_new['non_fitting_values'][k] for k in ('energy_bound_high',)]
+                #iterable << [param_model.param_new['non_fitting_values'][k] for k in sorted(list(param_model.param_new['non_fitting_values'].keys()))]
+                #iiterable << sorted_param(param_model)
+                Label:
+                    text = loop_item['description']
+                    maximum_size = 140
+                Container: cont:
+                    padding = Box(2, 2, 2, 2)
+                    constraints = [hbox(ff_bound_high, pb_bd_default)]
+                    FloatField: ff_bound_high:
+                        #value := loop_item['value']
+                        value := param_model.energy_bound_high_buf
+                        maximum_size = 100
+                    PushButton: pb_bd_default:
+                        text = 'Default'
+                        maximum_size = 100
+                        clicked ::
+                            ff_bound_high.value = loop_item['default_value']
+
+            Looper: 
+                iterable << [param_model.param_new['non_fitting_values'][k] for k in ('energy_bound_low',)]
                 #iterable << [param_model.param_new['non_fitting_values'][k] for k in sorted(list(param_model.param_new['non_fitting_values'].keys()))]
                 #iiterable << sorted_param(param_model)
                 Label:
@@ -851,15 +877,16 @@ enamldef AutoFindElements(Window): auto_win:
                     maximum_size = 140
                 Container:
                     padding = Box(2, 2, 2, 2)
-                    constraints = [hbox(ff_bound, pb_bd_default)]
-                    FloatField: ff_bound:
+                    constraints = [hbox(ff_bound_low, pb_bd_default)]
+                    FloatField: ff_bound_low:
                         value := loop_item['value']
                         maximum_size = 100
                     PushButton: pb_bd_default:
                         text = 'Default'
                         maximum_size = 100
                         clicked ::
-                            ff_bound.value = loop_item['default_value']
+                            ff_bound_low.value = loop_item['default_value']
+
 
         PushButton: find_btn:
             text = 'Find Elements'

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -859,7 +859,6 @@ enamldef AutoFindElements(Window): auto_win:
                     padding = Box(2, 2, 2, 2)
                     constraints = [hbox(ff_bound_high, pb_bd_default)]
                     FloatField: ff_bound_high:
-                        #value := loop_item['value']
                         value := param_model.energy_bound_high_buf
                         maximum_size = 100
                     PushButton: pb_bd_default:


### PR DESCRIPTION
Improved consistency of two dialog boxes: Automatic Element Finding in Fit tab and Options in Spectrum View tab.  
Now the upper limit for element finding (E high [keV]) is automatically set 0.8 keV higher than incident E when incident E is changed. E high may be changed manually. The value of the incident energy in Options dialog box is kept in sync with E high. It still can be changed, but I don't think it is used anywhere.