### PR TITLE
Fix for multiple issues related to data manipulation and presentation

### DIFF
--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -369,15 +369,25 @@ class DrawImageAdvanced(Atom):
                          cbar_pad='2%',
                          share_all=True)
 
-        def normalize_data_array(data_in, scaler, *, data_name, name_not_scalable):
+        def _normalize_data_array(data_in, scaler, *, data_name, name_not_scalable):
             ''' 
-            Normalize data based on the availability
-              data_in - numpy array
-              scaler - numpy array of the same size as data_in
-              data_name - string representing the name of the data set ('time' or 'i0' etc.)
-              name_not_scalable - list of names of not scalable datasets (['time', 'i0_time'])
-            Returns:
-              numpy array of the same size as data_in, data is normalized if necessary
+            Normalize data based on the availability of scaler
+            
+            Parameters
+            ----------
+
+            data_in : ndarray
+                numpy array of input data
+            scaler : ndarray 
+                numpy array of scaling data, the same size as data_in
+            data_name : str 
+                name of the data set ('time' or 'i0' etc.)
+            name_not_scalable : list 
+                names of not scalable datasets (['time', 'i0_time'])
+            
+            Returns
+            -------
+            ndarray with normalized data, the same shape as data_in
             '''
             if scaler is not None:
                 if data_name in name_not_scalable:
@@ -398,10 +408,10 @@ class DrawImageAdvanced(Atom):
         if self.scale_opt == 'Linear':
             for i, (k, v) in enumerate(six.iteritems(stat_temp)):
 
-                data_dict = normalize_data_array(data_in=self.dict_to_plot[k], 
-                                                 scaler=self.scaler_data, 
-                                                 data_name=k,
-                                                 name_not_scalable=self.name_not_scalable)
+                data_dict = _normalize_data_array(data_in=self.dict_to_plot[k], 
+                                                  scaler=self.scaler_data, 
+                                                  data_name=k,
+                                                  name_not_scalable=self.name_not_scalable)
 
                 low_ratio = self.limit_dict[k]['low']/100.0
                 high_ratio = self.limit_dict[k]['high']/100.0
@@ -450,10 +460,10 @@ class DrawImageAdvanced(Atom):
         else:
             for i, (k, v) in enumerate(six.iteritems(stat_temp)):
 
-                data_dict = normalize_data_array(data_in=self.dict_to_plot[k], 
-                                                 scaler=self.scaler_data, 
-                                                 data_name=k,
-                                                 name_not_scalable=self.name_not_scalable)
+                data_dict = _normalize_data_array(data_in=self.dict_to_plot[k], 
+                                                  scaler=self.scaler_data, 
+                                                  data_name=k,
+                                                  name_not_scalable=self.name_not_scalable)
 
                 maxz = np.max(data_dict)
 

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -434,15 +434,7 @@ class DrawImageAdvanced(Atom):
                     grid[i].set_ylim(max([self.y_pos[0], self.y_pos[-1]]), min([self.y_pos[0], self.y_pos[-1]]))
 
                 grid_title = k 
-                if self.pixel_or_pos or self.scatter_show:
-                    title_x = self.pixel_or_pos_upper_left_xy[0]
-                    title_y = self.pixel_or_pos_upper_left_xy[3] + (self.pixel_or_pos_upper_left_xy[3] -
-                                                                    self.pixel_or_pos_upper_left_xy[2])*0.04
-                else:
-                    title_x = 0
-                    title_y = - data_dict.shape[0]*0.05
-                
-                grid[i].text(title_x, title_y, grid_title)
+                grid[i].text(0, 1.01, grid_title, ha='left', va='bottom', transform=grid[i].axes.transAxes)
 
                 grid.cbar_axes[i].colorbar(im)                
                 grid.cbar_axes[i].ticklabel_format(style='sci', scilimits=(-3,4), axis='both')
@@ -488,14 +480,8 @@ class DrawImageAdvanced(Atom):
                     grid[i].set_ylim(max([self.y_pos[0], self.y_pos[-1]]), min([self.y_pos[0], self.y_pos[-1]]))
 
                 grid_title = k
-                if self.pixel_or_pos or self.scatter_show:
-                    title_x = self.pixel_or_pos_upper_left_xy[0]
-                    title_y = self.pixel_or_pos_upper_left_xy[3] + (self.pixel_or_pos_upper_left_xy[3] -
-                                                                    self.pixel_or_pos_upper_left_xy[2])*0.05
-                else:
-                    title_x = 0
-                    title_y = - data_dict.shape[0]*0.05
-                grid[i].text(title_x, title_y, grid_title)
+                grid[i].text(0, 1.01, grid_title, ha='left', va='bottom', transform=grid[i].axes.transAxes)
+
                 grid.cbar_axes[i].colorbar(im)
 
                 grid[i].get_xaxis().get_major_formatter().set_useOffset(False)

--- a/pyxrf/model/draw_image_rgb.py
+++ b/pyxrf/model/draw_image_rgb.py
@@ -186,6 +186,7 @@ class DrawImageRGB(Atom):
             # for GUI purpose only
             self.scaler_items = []
             self.scaler_items = list(self.scaler_norm_dict.keys())
+            self.scaler_items.sort()
             self.scaler_data = None
 
         self.show_image()
@@ -222,6 +223,7 @@ class DrawImageRGB(Atom):
 
     @observe('scaler_name_index')
     def _get_scaler_data(self, change):
+
         if self.scaler_name_index == 0:
             self.scaler_data = None
         else:
@@ -279,13 +281,19 @@ class DrawImageRGB(Atom):
                 selected_name.append(k) #self.file_name+'_'+str(k)
 
         else:
+            # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            # This block of code should not be executed, since 'self.ic_norm' is not defined
+            # Currently log scale presentation of data is disabled
             for i, (k, v) in enumerate(six.iteritems(stat_temp)):
 
                 if self.scaler_data is not None:
                     if k in self.name_not_scalable:
                         data_dict = np.log(self.dict_to_plot[k])
                     else:
-                        data_dict = np.log(self.dict_to_plot[k]/self.scaler_data*self.ic_norm)
+                        # Modified code (just in case this block is called)
+                        data_dict = np.log(self.dict_to_plot[k]/self.scaler_data)
+                        # Original code (decide how to define 'self.ic_norm' before enabling log scale
+                        #data_dict = np.log(self.dict_to_plot[k]/self.scaler_data*self.ic_norm)
 
                 else:
                     data_dict = np.log(self.dict_to_plot[k])
@@ -305,12 +313,10 @@ class DrawImageRGB(Atom):
         selected_data, selected_name = self.preprocess_data()
         selected_data = np.asarray(selected_data)
 
-        if len(selected_name) >0 and len(selected_name) < 3:
+        if len(selected_name) != 3:
             logger.error('Please select three elements for RGB plot.')
-        elif len(selected_name) >= 3:
-            if len(selected_name) > 3:
-                logger.warning('Please select only three elements for RGB plot.')
-            self.rgb_name_list = selected_name[:3]
+            return
+        self.rgb_name_list = selected_name[:3]
 
         try:
             data_r = selected_data[0,:,:]
@@ -368,8 +374,8 @@ class DrawImageRGB(Atom):
         self.ax_g.imshow(G, **kwargs)
         self.ax_b.imshow(B, **kwargs)
 
-        self.ax.set_xticklabels([])
-        self.ax.set_yticklabels([])
+        #self.ax.set_xticklabels([])
+        #self.ax.set_yticklabels([])
 
         # sb_x = 38
         # sb_y = 46

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -120,7 +120,7 @@ def make_hdf(start, end=None, fname=None,
         one file is transfered.
     prefix : str, optional
         prefix name of the file
-    db : databroker
+    db : databrokerf
     create_each_det: bool, optional
         Do not create data for each detector is data size is too large,
         if set as false. This will slow down the speed of creating hdf file

--- a/pyxrf/view/fileio.enaml
+++ b/pyxrf/view/fileio.enaml
@@ -83,6 +83,7 @@ enamldef FileView(DockItem): file_view:
                     hbox(gb_fit),
                     hbox(mask_opt, spacer),
                     scroller,
+                    plot_bt
                 ),
                 folder_btn.width == files_btn.width,
                 #folder_btn.width == mask_btn.width,
@@ -112,6 +113,7 @@ enamldef FileView(DockItem): file_view:
                                                             selected_name_filter="*.h5",
                                                             current_path=io_model.working_directory)
                     if path:
+                        io_model.data_ready = False
                         # only load one file
                         # 'temp' is used to reload the same file, otherwise file_name will not update
                         io_model.file_name = 'temp'
@@ -135,6 +137,8 @@ enamldef FileView(DockItem): file_view:
                             setting_model.data_sets = io_model.data_sets
                             fit_model.data_sets = io_model.data_sets
                             fit_model.fit_img = {} # clear dict in fitmodel to rm old results
+
+                            plot_bt.enabled = True
 
             Label: files_load:
                 text = 'No data is loaded.'
@@ -163,6 +167,9 @@ enamldef FileView(DockItem): file_view:
                     enabled = databroker is not None
                     text = "Load Data from Database"
                     clicked ::
+                        
+                        io_model.data_ready = False
+
                         io_model.load_data_runid()
 
                         files_load.text = '{} is loaded from database.'.format(io_model.fname_from_db)
@@ -179,13 +186,16 @@ enamldef FileView(DockItem): file_view:
                         #setting_model.data_sets = io_model.data_sets
                         #fit_model.save_name = io_model.file_names[0]
 
+                        plot_bt.enabled = True
+
+
             GroupBox: gb_fit:
                 constraints = [hbox(fit_lbl, cb_select, spacer)]
                 Label : fit_lbl:
-                    text = 'Which channel data for fitting'
+                    text = 'Select channel data for fitting'
                     foreground = 'blue'
                 ComboBox: cb_select:
-                    items << ['Select Data '] + list(io_model.file_channel_list)
+                    items << list(io_model.file_channel_list)
                     index = 0
                     index := io_model.file_opt
                     minimum_size = (300, 16)
@@ -216,6 +226,28 @@ enamldef FileView(DockItem): file_view:
                                     #plot_bt.enabled = True
                                     plot_model.data_sets = io_model.data_sets
 
+            PushButton: plot_bt:
+                text = 'Plot Experiments'
+                #maximum_size = 100
+                enabled = False
+                checkable = True
+                checked << plot_model.show_exp_opt
+                clicked ::
+                    plot_model.data_sets = io_model.data_sets
+                    plot_model.plot_multi_exp_data()
+                    if checked:
+                        n_plots = 0
+                        for v in io_model.file_channel_list:
+                            if io_model.data_sets[v].plot_index:
+                                n_plots += 1
+                        if n_plots: 
+                            plot_bt.text = 'Remove Plot'
+                            plot_model.show_exp_opt = True
+                        else:
+                            plot_bt.checked = False
+                    else:
+                        plot_model.show_exp_opt = False
+                        plot_bt.text = 'Plot Experiments'
 
 enamldef MaskView(Window): mask_view:
     attr io_model


### PR DESCRIPTION
Fixed multiple issues related to data manipulation and presentation, including but not limited to
- loading and presentation of data from multichannel (3-channel) detectors;
- selection of individual detector channels or sum of all channels for further processing (fitting of elements);
- plotting data from different detector channel on the same plot for comparison;
- automatic scaling of the 'Spectrum View' plot (now works well in most situations, may be manually reset in the rest of cases);
- multiple issues in 'Element RGB' tab: enabled axes tick labels (no coordinates of x and y are printed in the toolbar along with values, not x= y= without values); fixed the issue with program crashing of less than 3 elements are selected for plotting; fixed mismatch between the order of scalers in 'Normalized by' menu and the list that is used internally (now the applied scaler is the same as the selected scaler); and some minor issues.
