### PR TITLE
Loading multichannel detector data using Databroker

### DIFF
--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -55,7 +55,7 @@ import ast
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 from atom.api import Atom, Str, observe, Typed, Dict, List, Int, Enum, Float, Bool
-from .load_data_from_db import (db, fetch_data_from_db,
+from .load_data_from_db import (db, fetch_data_from_db, flip_data,
                                 helper_encode_list, helper_decode_list)
 
 import logging
@@ -412,46 +412,7 @@ def read_xspress3_data(file_path):
 
     return data_output
 
-
-def flip_data(input_data, subscan_dims=None):
-    """
-    Flip 2D or 3D array. The flip happens on the second index of shape.
-    .. warning :: This function mutates the input values.
-
-    Parameters
-    ----------
-    input_data : 2D or 3D array.
-
-    Returns
-    -------
-    flipped data
-    """
-    new_data = np.asarray(input_data)
-    data_shape = input_data.shape
-    if len(data_shape) == 2:
-        if subscan_dims is None:
-            new_data[1::2, :] = new_data[1::2, ::-1]
-        else:
-            i = 0
-            for nx, ny in subscan_dims:
-                start = i + 1
-                end = i + ny
-                new_data[start:end:2, :] = new_data[start:end:2, ::-1]
-                i += ny
-
-    if len(data_shape) == 3:
-        if subscan_dims is None:
-            new_data[1::2, :, :] = new_data[1::2, ::-1, :]
-        else:
-            i = 0
-            for nx, ny in subscan_dims:
-                start = i + 1
-                end = i + ny
-                new_data[start:end:2, :, :] = new_data[start:end:2, ::-1, :]
-                i += ny
-    return new_data
-
-
+    
 def output_data(fpath, output_folder,
                 file_format='tiff', norm_name=None, use_average=True):
     """

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -160,7 +160,7 @@ def make_hdf(start, end=None, fname=None,
         one file is transfered.
     prefix : str, optional
         prefix name of the file
-    db : databrokerf
+    db : databroker
     create_each_det: bool, optional
         Do not create data for each detector is data size is too large,
         if set as false. This will slow down the speed of creating hdf file

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -82,7 +82,6 @@ def flip_data(input_data, subscan_dims=None):
     return new_data
 
 
-
 def fetch_data_from_db(runid, fpath=None,
                        create_each_det=False,
                        output_to_file=False,
@@ -332,7 +331,7 @@ def map_data2D_srx(runid, fpath,
         if num_end_lines_excluded is None:
             datashape = [start_doc['shape'][1], start_doc['shape'][0]]   # vertical first then horizontal, assuming fast scan on x
         else:
-            datashape = [start_doc['shape'][1]-num_end_lines_excluded, start_doc['shape'][0]]
+            datashape = [start_doc['shape'][1] - num_end_lines_excluded, start_doc['shape'][0]]
         
         snake_scan = start_doc.get('snaking')
         if snake_scan[1] == True:
@@ -376,7 +375,7 @@ def map_data2D_srx(runid, fpath,
             if 'xs2' in hdr.start.detectors:
                 print('Saving data to hdf file for second xspress3 detector.')
                 root, ext = os.path.splitext(fpath)
-                fpath1 = ''.join([root+'_1', ext])
+                fpath1 = f"{root + '_1'}{ext}"
                 write_db_to_hdf(fpath1, data,
                                 datashape,
                                 det_list=config_data['xrf_detector2'],
@@ -400,7 +399,6 @@ def map_data2D_srx(runid, fpath,
 
         num_det = 0  # Some default value (should never be used)
 
-            
         # Added by AMK to allow flying of single element on xs2
         #if 'E_tomo' in start_doc['scaninfo']['type']:
         #    num_det = 1
@@ -451,7 +449,7 @@ def map_data2D_srx(runid, fpath,
                     new_data['det_sum'] = np.zeros(new_shape)
                 else:
                     for i in range(num_det):
-                        new_data['det'+str(i+1)] = np.zeros(new_shape)
+                        new_data[f'det{i + 1}'] = np.zeros(new_shape)
 
                 print(f"Number of the detector channels: {num_det}")
             
@@ -486,7 +484,7 @@ def map_data2D_srx(runid, fpath,
         s = f"_sum({num_det}ch)"
         if create_each_det:
             s += f"+{num_det}ch"
-        fpath = ''.join([root+s, ext])
+        fpath = f'{root + s}{ext}'
                         
         if vertical_fast is True: # need to transpose the data, as we scan y first
             if create_each_det is False:

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -438,6 +438,9 @@ def map_data2D_srx(runid, fpath,
             for v in scaler_list+[xpos_name]:
                 data[v] = np.zeros([datashape[0], datashape[1]])
 
+        # Total number of lines in fly scan
+        n_scan_lines_total = new_shape[0]
+
         for m, v in enumerate(e):
 
             if m == 0:
@@ -466,7 +469,7 @@ def map_data2D_srx(runid, fpath,
                             data[n][m, min_len:datashape[1]] = interp_list
                 fluor_len = v.data['fluor'].shape[0]
                 if m > 0 and not (m % 10):
-                    print(f"Processed #{m} lines ...")
+                    print(f"Processed {m} of {n_scan_lines_total} lines ...")
                 # print(f"m = {m} Data shape {v.data['fluor'].shape} - {v.data['fluor'].shape[1] }")
                 # print(f"Data keys: {v.data.keys()}")
                 if create_each_det is False:


### PR DESCRIPTION
Fixed multiple issues related to loading of experimental data using Databroker. The main issues:

- Function ```make_hdf``` was not considering 3-channel data from Xpress3 detector as 1-channel data. When computing the sum of channels, only data from channel 1 was used. The fixed code correctly determines the number of channels in the input stream (using table dimensions) and uses complete data for calculations. Changes are only related to fly scan mode on the SRX beamline;

- Function ```make_hdf``` was crashing in attempt to load step-scan data from Databroker. The fixed code allows to load step-scan data from one or two Xpress 3 detectors. Code changes are only relevant for step scan data from SRX beamline.

Testing was performed on SRX WS4.