### PR TITLE
New feature: `make_hdf` can load flyscan data from two detectors

### DIFF
--- a/configs/srx_pv_config.json
+++ b/configs/srx_pv_config.json
@@ -5,6 +5,10 @@
     "xrf_roi_pv": {
         "Pt_9300_9600": ["Ch1 [9300:9600]", "Ch2 [9300:9600]", "Ch3 [9300:9600]"]
     },
+    "xrf_flyscan_detector_fields": {
+        "fluor": "xs",
+        "fluor_xs2": "xs2"
+    },
     "pos_list": ["hf_stage_x", "hf_stage_y"],
     "scaler_list": ["sclr_i0"],
     "base_value": [0]

--- a/configs/srx_pv_config.json
+++ b/configs/srx_pv_config.json
@@ -1,6 +1,6 @@
 {
     "beamline": "SRX",
-    "xrf_detector": ["xs_settings_ch1", "xs_settings_ch2", "xs_settings_ch3"],
+    "xrf_detector": ["xs_channel1", "xs_channel2", "xs_channel3"],
     "xrf_detector2": ["xs2_channel1"],
     "xrf_roi_pv": {
         "Pt_9300_9600": ["Ch1 [9300:9600]", "Ch2 [9300:9600]", "Ch3 [9300:9600]"]

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -348,7 +348,9 @@ def map_data2D_srx(runid, fpath,
 
 
         try:
-            data = db.get_table(hdr, fill=True, convert_times=False)
+            #data = db.get_table(hdr, fill=True, convert_times=False)
+            data = hdr.table(fill=True, convert_times=False)
+
         except IndexError:
             total_len = get_total_scan_point(hdr) - 2
             evs, _ = zip(*zip(get_events(hdr, fill=True), range(total_len)))
@@ -449,7 +451,8 @@ def map_data2D_srx(runid, fpath,
         for detector_field, detector_name in detector_field_dict.items():
 
             # Assume that Databroker caches the tables locally, so that data will not be reloaded
-            e = db.get_events(hdr, fill=True, stream_name=des.name)
+            #e = db.get_events(hdr, fill=True, stream_name=des.name)
+            e = hdr.events(fill=True, stream_name=des.name)
 
             new_data = {}
             data = {}
@@ -551,7 +554,8 @@ def map_data2D_srx(runid, fpath,
                 x_pos = np.vstack(data[xpos_name])
 
                 # get y position data, from differet stream name primary
-                data1 = db.get_table(hdr, fill=True, stream_name='primary')
+                #data1 = db.get_table(hdr, fill=True, stream_name='primary')
+                data1 = hdr.table(fill=True, stream_name='primary')
                 if num_end_lines_excluded is not None:
                     data1 = data1[:datashape[0]]
                 # if ypos_name not in data1.keys() and 'E_tomo' not in start_doc['scaninfo']['type']:

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -382,7 +382,7 @@ def map_data2D_srx(runid, fpath,
             if 'xs2' in hdr.start.detectors:
                 print('Saving data to hdf file: Xpress3 detector #2 (single channel).')
                 root, ext = os.path.splitext(fpath)
-                fpath_out = f"{root + '_xs2'}{ext}"
+                fpath_out = f"{root}_xs2{ext}"
                 write_db_to_hdf(fpath_out, data,
                                 datashape,
                                 det_list=config_data['xrf_detector2'],
@@ -526,7 +526,7 @@ def map_data2D_srx(runid, fpath,
             s = f"_{detector_name}_sum({num_det}ch)"
             if create_each_det:
                 s += f"+{num_det}ch"
-            fpath_out = f'{root + s}{ext}'
+            fpath_out = f'{root}{s}{ext}'
 
             if vertical_fast is True: # need to transpose the data, as we scan y first
                 if create_each_det is False:

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -348,7 +348,6 @@ def map_data2D_srx(runid, fpath,
 
 
         try:
-            #data = db.get_table(hdr, fill=True, convert_times=False)
             data = hdr.table(fill=True, convert_times=False)
 
         except IndexError:
@@ -451,7 +450,6 @@ def map_data2D_srx(runid, fpath,
         for detector_field, detector_name in detector_field_dict.items():
 
             # Assume that Databroker caches the tables locally, so that data will not be reloaded
-            #e = db.get_events(hdr, fill=True, stream_name=des.name)
             e = hdr.events(fill=True, stream_name=des.name)
 
             new_data = {}
@@ -554,7 +552,6 @@ def map_data2D_srx(runid, fpath,
                 x_pos = np.vstack(data[xpos_name])
 
                 # get y position data, from differet stream name primary
-                #data1 = db.get_table(hdr, fill=True, stream_name='primary')
                 data1 = hdr.table(fill=True, stream_name='primary')
                 if num_end_lines_excluded is not None:
                     data1 = data1[:datashape[0]]


### PR DESCRIPTION
The feature was requested by Andy K.

`make_hdf` may load from two detectors (`xs` - 3 channels and `xs2` - 1 channel) and create two separate files. It is assumed that data from detector `xs` can be accessed using the field `fluor` and the detector `xs2` using the field name `fluor_xs2`. The names of the field and associated detector names are now read from configuration file `/configs/srx_pv_config.json`. The detector names associated with field names are added to data file names to distinguish between files. It is also seems reasonable to recommend to permanently change experiment plans so that data from the detector `xs2` are always saved with field name 'fluor_xs2'

Additional changes to the configuration file `/configs/srx_pv_config.json`: field names for `xrf_detector` were changed and are now consistent with all the sample data (scan IDs) that I have. `xrf_detector` and `xrf_detector2` specify fields for `xs` and `xs2` detectors used while recording stepscans.