### PR TITLE
Fix: two cases of PyXRF crashing

### DIFF
--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -41,6 +41,7 @@ from collections import OrderedDict
 from scipy.interpolate import interp1d, interp2d
 import copy
 
+import math
 import matplotlib
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
@@ -512,6 +513,11 @@ class DrawImageAdvanced(Atom):
                 low_limit = (maxv-minv)*low_ratio + minv
                 high_limit = (maxv-minv)*high_ratio + minv
 
+                # Set some minimum range for the colorbar (otherwise it will have white fill)
+                if math.isclose(low_limit, high_limit, abs_tol=2e-20):
+                    high_limit += 1e-20
+                    low_limit -= 1e-20
+
                 if self.scatter_show is not True:
                     im = grid[i].imshow(data_dict,
                                         cmap=grey_use,
@@ -552,6 +558,10 @@ class DrawImageAdvanced(Atom):
             else:
 
                 maxz = np.max(data_dict)
+                # Set some reasonable minimum range for the colorbar
+                #   Zeros or negative numbers will be shown in white
+                if maxz <= 1e30:
+                    maxz = 1
 
                 if self.scatter_show is not True:
                     im = grid[i].imshow(data_dict,
@@ -573,6 +583,7 @@ class DrawImageAdvanced(Atom):
                                          linewidths=1, linewidth=0,
                                          clim=(low_lim*maxz, maxz))
                     grid[i].set_ylim(yd_axis_min, yd_axis_max)
+
 
                 grid[i].set_xlim(xd_axis_min, xd_axis_max)
 

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -560,7 +560,7 @@ class DrawImageAdvanced(Atom):
                 maxz = np.max(data_dict)
                 # Set some reasonable minimum range for the colorbar
                 #   Zeros or negative numbers will be shown in white
-                if maxz <= 1e30:
+                if maxz <= 1e-30:
                     maxz = 1
 
                 if self.scatter_show is not True:

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -584,7 +584,6 @@ class DrawImageAdvanced(Atom):
                                          clim=(low_lim*maxz, maxz))
                     grid[i].set_ylim(yd_axis_min, yd_axis_max)
 
-
                 grid[i].set_xlim(xd_axis_min, xd_axis_max)
 
                 grid_title = k

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -1454,7 +1454,7 @@ def fit_per_line_nnls(row_num, data,
 
         result, res = nnls_fit(y, matv, weights=None)
         sst = np.sum((y-np.mean(y))**2)
-        if not math.isclose(sst, 0, abs_tol=1e-10):
+        if not math.isclose(sst, 0, abs_tol=1e-20):
             r2_adjusted = 1 - res / (num_data - num_feature - 1) / (sst / (num_data - 1))
         else:
             # This happens if all elements of 'y' are equal (most likely == 0)

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -1453,7 +1453,12 @@ def fit_per_line_nnls(row_num, data,
 
         result, res = nnls_fit(y, matv, weights=None)
         sst = np.sum((y-np.mean(y))**2)
-        r2_adjusted = 1 - res/(num_data-num_feature-1)/(sst/(num_data-1))
+        import math
+        if not math.isclose(sst, 0, abs_tol=1e-10):
+            r2_adjusted = 1 - res / (num_data - num_feature - 1) / (sst / (num_data - 1))
+        else:
+            # This happens if all elements of 'y' are equal (most likely == 0)
+            r2_adjusted = 0
         result = list(result) + [bg_sum, r2_adjusted]
         out.append(result)
     return np.array(out)

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -40,6 +40,7 @@ import time
 import copy
 import six
 import os
+import math
 from collections import OrderedDict, deque
 import multiprocessing
 import h5py
@@ -1453,7 +1454,6 @@ def fit_per_line_nnls(row_num, data,
 
         result, res = nnls_fit(y, matv, weights=None)
         sst = np.sum((y-np.mean(y))**2)
-        import math
         if not math.isclose(sst, 0, abs_tol=1e-10):
             r2_adjusted = 1 - res / (num_data - num_feature - 1) / (sst / (num_data - 1))
         else:


### PR DESCRIPTION
PyXRF was reported by to crash while plotting data for scan IDs 29929 and 29933. Two minor errors were corrected: rarely occurring division by 0 and plotting all-zeros image with imshow().