### PR TITLE
Fix source distribution for PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,15 @@
-include versioneer.py
-include requirements.txt
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+include LICENSE
+include MANIFEST.in
+include README.md
+
 include pyxrf/_version.py
+include versioneer.py
+
+include requirements.txt
+
+recursive-include configs *.json
+recursive-include docs *.rst conf.py Makefile make.bat _static/*
+recursive-include * *.enaml


### PR DESCRIPTION
This PR fixes the issue with broken `.tar.gz` files being submitted to PyPI.

The dirs/files tree is as follows with this fix:
```
16:41 $ tree pyxrf-0.0.9.7+0.g7de7f75.dirty
pyxrf-0.0.9.7+0.g7de7f75.dirty
├── LICENSE
├── MANIFEST.in
├── PKG-INFO
├── README.md
├── configs
│   ├── hxn_pv_config.json
│   ├── pv_config.json
│   ├── srx_pv_config-original.json
│   ├── srx_pv_config.json
│   ├── xfm_pv_config.json
│   └── xrf_parameter.json
├── docs
│   ├── Makefile
│   ├── _static
│   │   ├── define_h5file.jpg
│   │   ├── define_h5file.pdf
│   │   ├── define_h5file.png
│   │   ├── load_parameter_file.png
│   │   ├── more_datasets.png
│   │   ├── select_data_plot.png
│   │   └── zoomin_plot.png
│   ├── conf.py
│   ├── credits.rst
│   ├── data_input.rst
│   ├── data_output.rst
│   ├── index.rst
│   ├── installation.rst
│   ├── make.bat
│   ├── questions.rst
│   ├── summed_spectrum_fit.rst
│   └── work_at_beamlines.rst
├── pyxrf
│   ├── __init__.py
│   ├── _version.py
│   ├── api.py
│   ├── db_config
│   │   ├── __init__.py
│   │   ├── hxn_db_config.py
│   │   ├── srx_db_config.py
│   │   └── xfm_db_config.py
│   ├── gui.py
│   ├── model
│   │   ├── __init__.py
│   │   ├── command_tools.py
│   │   ├── data_to_analysis_store.py
│   │   ├── draw_image.py
│   │   ├── draw_image_rgb.py
│   │   ├── fileio.py
│   │   ├── fit_spectrum.py
│   │   ├── guessparam.py
│   │   ├── lineplot.py
│   │   ├── load_data_from_db.py
│   │   ├── param_data.py
│   │   └── setting.py
│   └── view
│       ├── __init__.py
│       ├── fileio.enaml
│       ├── fit.enaml
│       ├── guessparam.enaml
│       ├── image2D.enaml
│       ├── lineplot.enaml
│       ├── main_window.enaml
│       ├── rgb_image.enaml
│       └── setting.enaml
├── pyxrf.egg-info
│   ├── PKG-INFO
│   ├── SOURCES.txt
│   ├── dependency_links.txt
│   ├── entry_points.txt
│   ├── requires.txt
│   └── top_level.txt
├── setup.cfg
├── setup.py
└── versioneer.py

8 directories, 66 files
```