### PR TITLE
Fix: image contrast adjustment in RGB data plot

### DIFF
--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -299,7 +299,10 @@ class DrawImageAdvanced(Atom):
         This function is used for formatting of range values in 'Image Wizard'.
         The presentation of the number was tweaked so that it is nicely formatted
            in the enaml field with adequate precision.
-        NOTE: The function is called externally from 'enaml' code.
+
+        ..note::
+        
+        The function is called externally from 'enaml' code.
 
         Parameters:
         ===========
@@ -360,8 +363,8 @@ class DrawImageAdvanced(Atom):
                                              data_name=data_name, name_not_scalable=self.name_not_scalable)
             lowv = np.min(data_arr)
             highv = np.max(data_arr)
-            self.range_dict[data_name] = {'low':lowv, 'low_default':lowv,
-                                          'high':highv, 'high_default':highv}
+            self.range_dict[data_name] = {'low': lowv, 'low_default': lowv,
+                                          'high': highv, 'high_default': highv}
 
     def reset_low_high(self, name):
         """Reset low and high value to default based on normalization.

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -90,8 +90,6 @@ class DrawImageAdvanced(Atom):
         index to select on GUI level
     scaler_data : None or numpy
         selected scaler data
-    plot_all : Bool
-        to control plot all of the data or not
     x_pos : list
         define data range in horizontal direction
     y_pos : list
@@ -122,7 +120,6 @@ class DrawImageAdvanced(Atom):
     scaler_name_index = Int()
     scaler_data = Typed(object)
 
-    plot_all = Bool(False)
     x_pos = List()
     y_pos = List()
 
@@ -203,7 +200,7 @@ class DrawImageAdvanced(Atom):
         self.data_opt = 0
         # init of scaler for normalization
         self.scaler_name_index = 0
-        self.plot_all = False
+        self.plot_deselect_all()
 
     def get_default_items(self):
         """Add previous selected items as default.
@@ -276,12 +273,11 @@ class DrawImageAdvanced(Atom):
     def _update_pp(self, change):
             self.show_image()
 
-    @observe('plot_all')
-    def _update_all_plot(self, change):
-        if self.plot_all is True:
-            self.set_stat_for_all(bool_val=True)
-        else:
-            self.set_stat_for_all(bool_val=False)
+    def plot_select_all(self):
+        self.set_stat_for_all(bool_val=True)
+
+    def plot_deselect_all(self):
+        self.set_stat_for_all(bool_val=False)
 
     @observe('scatter_show')
     def _change_image_plot_method(self, change):

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -311,7 +311,7 @@ class DrawImageAdvanced(Atom):
         str - the string representation of the floating point variable
         """
         if value != 0:
-            value_log10 = math.log10(value)
+            value_log10 = math.log10(abs(value))
         else:
             value_log10 = 0
         if (value_log10 > 3) or (value_log10 < -3):

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -311,14 +311,14 @@ class DrawImageAdvanced(Atom):
                 data_dict = self.dict_to_plot[k]
             lowv = np.min(data_dict)
             highv = np.max(data_dict)
-            self.range_dict[k] = {'low':lowv, 'low_defualt':lowv,
-                                  'high':highv, 'high_defualt':highv}
+            self.range_dict[k] = {'low':lowv, 'low_default':lowv,
+                                  'high':highv, 'high_default':highv}
 
     def reset_low_high(self, name):
         """Reset low and high value to default based on normalization.
         """
-        self.range_dict[name]['low'] = self.range_dict[name]['low_defualt']
-        self.range_dict[name]['high'] = self.range_dict[name]['high_defualt']
+        self.range_dict[name]['low'] = self.range_dict[name]['low_default']
+        self.range_dict[name]['high'] = self.range_dict[name]['high_default']
         self.limit_dict[name]['low'] = 0.0
         self.limit_dict[name]['high'] = 100.0
         self.update_img_wizard_items()

--- a/pyxrf/model/draw_image_rgb.py
+++ b/pyxrf/model/draw_image_rgb.py
@@ -416,7 +416,6 @@ class DrawImageRGB(Atom):
         data_g = _norm_data(data_g)
         data_b = _norm_data(data_b)
 
-        # set limit, there should be a better way to do this
         data_r = _stretch_range(data_r, rgb_l_h[self.index_red]['low'], rgb_l_h[self.index_red]['high'])
         data_g = _stretch_range(data_g, rgb_l_h[self.index_green]['low'], rgb_l_h[self.index_green]['high'])
         data_b = _stretch_range(data_b, rgb_l_h[self.index_blue]['low'], rgb_l_h[self.index_blue]['high'])

--- a/pyxrf/model/draw_image_rgb.py
+++ b/pyxrf/model/draw_image_rgb.py
@@ -391,7 +391,8 @@ class DrawImageRGB(Atom):
             ----------
             data : 2D array
             """
-            return (data - np.min(data)) / (np.max(data) - np.min(data))
+            data_min = np.min(data)
+            return (data - data_min) / (np.max(data) - data_min)
 
         def _stretch_range(data_in, v_low, v_high):
 
@@ -407,10 +408,8 @@ class DrawImageRGB(Atom):
             v_low, v_high = v_low / 100.0, v_high / 100.0
             c = 1.0 / (v_high - v_low)
             data_out = (data_in - v_low) * c
-            data_out[data_out < 0.0] = 0.0
-            data_out[data_out > 1.0] = 1.0
 
-            return data_out
+            return np.clip(data_out, 0, 1.0)
 
         # Normalize data
         data_r = _norm_data(data_r)

--- a/pyxrf/model/draw_image_rgb.py
+++ b/pyxrf/model/draw_image_rgb.py
@@ -404,7 +404,7 @@ class DrawImageRGB(Atom):
             if v_high - v_low < 1:  # This should not happen in practice, but check just in case
                 v_high = v_low + 1
 
-            v_low, v_high = v_low/100.0, v_high/100.0
+            v_low, v_high = v_low / 100.0, v_high / 100.0
             c = 1.0 / (v_high - v_low)
             data_out = (data_in - v_low) * c
             data_out[data_out < 0.0] = 0.0

--- a/pyxrf/model/draw_image_rgb.py
+++ b/pyxrf/model/draw_image_rgb.py
@@ -380,13 +380,13 @@ class DrawImageRGB(Atom):
         name_b = self.rgb_name_list[self.index_blue]
         data_b = selected_data[self.index_blue,:,:]
 
-        rgb_l_h = ({'low':self.r_low, 'high':self.r_high},
-                   {'low':self.g_low, 'high':self.g_high},
-                   {'low':self.b_low, 'high':self.b_high})
+        rgb_l_h = ({'low': self.r_low, 'high': self.r_high},
+                   {'low': self.g_low, 'high': self.g_high},
+                   {'low': self.b_low, 'high': self.b_high})
 
         def _norm_data(data):
             """
-            Normalize data between (0,1).
+            Normalize data between (0, 1).
             Parameters
             ----------
             data : 2D array
@@ -405,7 +405,7 @@ class DrawImageRGB(Atom):
                 v_high = v_low + 1
 
             v_low, v_high = v_low/100.0, v_high/100.0
-            c = 1.0/(v_high-v_low)
+            c = 1.0 / (v_high - v_low)
             data_out = (data_in - v_low) * c
             data_out[data_out < 0.0] = 0.0
             data_out[data_out > 1.0] = 1.0

--- a/pyxrf/view/image2D.enaml
+++ b/pyxrf/view/image2D.enaml
@@ -208,7 +208,7 @@ enamldef ChooseElementAdvanced(Window): win:
                                         dual_slider.high_value = 100
                                         #img_model.reset_low_high(loop_item)
 
-            # 'Save Selected as Default' button does not serve any useful purpose now, but it
+            # 'Save Selected as Default' button does not serve any useful purpose now, but
             #    it may make sense to implement it properly in the future. So I commented
             #    the code to temporarily eliminate non-functional controls.
             # PushButton: save_selected:

--- a/pyxrf/view/image2D.enaml
+++ b/pyxrf/view/image2D.enaml
@@ -129,6 +129,7 @@ enamldef ChooseElementAdvanced(Window): win:
     attr img_model
 
     title = 'Select Elements to Plot'
+    initial_size = (900, 500)
     Container:
         constraints = [
             vbox(

--- a/pyxrf/view/image2D.enaml
+++ b/pyxrf/view/image2D.enaml
@@ -144,8 +144,8 @@ enamldef ChooseElementAdvanced(Window): win:
         GroupBox: gb:
             constraints = [vbox(
                                 hbox(select_all_btn, deselect_all_btn, spacer),
-                                hbox(scroll_select),
-                                hbox(save_selected, spacer),)
+                                hbox(scroll_select),)
+                                # hbox(save_selected, spacer),)
                           ]
             title = 'Add/Remove Image'
             PushButton: select_all_btn:
@@ -194,19 +194,26 @@ enamldef ChooseElementAdvanced(Window): win:
                                     maximum = 100
                                     low_value >> img_model.limit_dict[loop_item]['low']
                                     high_value >> img_model.limit_dict[loop_item]['high']
-                                FloatField: ff_low:
-                                    value := img_model.range_dict[loop_item]['low']
-                                FloatField: ff_high:
-                                    value := img_model.range_dict[loop_item]['high']
+                                Field: ff_low:
+                                    read_only = True
+                                    text << img_model.format_img_wizard_limit(img_model.range_dict[loop_item]['low'])
+                                Field: ff_high:
+                                    read_only = True
+                                    text << img_model.format_img_wizard_limit(img_model.range_dict[loop_item]['high'])
                                 PushButton: reset_btn:
-                                    text = 'Reset Low & High'
+                                    text = 'Reset'
                                     clicked ::
-                                        img_model.reset_low_high(loop_item)
+                                        dual_slider.low_value = 0
+                                        dual_slider.high_value = 100
+                                        #img_model.reset_low_high(loop_item)
 
-            PushButton: save_selected:
-                text = 'Save Selected as Default'
-                clicked ::
-                    img_model.record_selected()
+            # 'Save Selected as Default' button does not serve any useful purpose now, but it
+            #    it may make sense to implement it properly in the future. So I commented
+            #    the code to temporarily eliminate non-functional controls.
+            # PushButton: save_selected:
+            #     text = 'Save Selected as Default'
+            #     clicked ::
+            #         img_model.record_selected()
 
 
 def get_status(dictv, name):

--- a/pyxrf/view/image2D.enaml
+++ b/pyxrf/view/image2D.enaml
@@ -138,16 +138,27 @@ enamldef ChooseElementAdvanced(Window): win:
         ]
 
         PushButton: plot_btn:
-            text = 'Show Image'
+            text = 'Update Plot'
             clicked ::
                 img_model.show_image()
         GroupBox: gb:
+            constraints = [vbox(
+                                hbox(select_all_btn, deselect_all_btn, spacer),
+                                hbox(scroll_select),
+                                hbox(save_selected, spacer),)
+                          ]
             title = 'Add/Remove Image'
-            PushButton: select_btn:
+            PushButton: select_all_btn:
                 text = 'Select All'
-                checkable = True
-                checked := img_model.plot_all
-            ScrollArea:
+                checkable = False
+                clicked ::
+                    img_model.plot_select_all()
+            PushButton: deselect_all_btn:
+                text = 'Deselect All'
+                checkable = False
+                clicked ::
+                    img_model.plot_deselect_all()
+            ScrollArea: scroll_select:
                 constraints = [height >= 80]
                 Container:
                     Form:
@@ -162,10 +173,7 @@ enamldef ChooseElementAdvanced(Window): win:
                                     text = 'Select'
                                     minimum_size = (40, 20)
                                     checkable = True
-                                    #checked << img_model.plot_all
-                                    #checked << getattr(img_model.stat_dict, loop_item, False)
                                     checked << get_status(img_model.stat_dict, loop_item)
-                                    #checked << img_model.stat_dict[loop_item]
                                     clicked ::
                                         if checked:
                                             img_model.stat_dict[loop_item] = True

--- a/pyxrf/view/rgb_image.enaml
+++ b/pyxrf/view/rgb_image.enaml
@@ -91,7 +91,7 @@ enamldef ImageRGB(DockItem):
             index := img_model_adv.scaler_name_index
 
         PushButton: plot_btn:
-            text = 'Show Image'
+            text = 'Update Plot'
             clicked ::
                 img_model_adv.show_image()
 


### PR DESCRIPTION
The pull request includes two fixes (requested by @andrewmkiss:
- Image contrast adjustment in RGB data plot is functioning properly now: the presented range of values (min and max) is selected for each color (R, G and B) using sliders; the presented data is scaled so that values within the range fill the whole dynamic range of the RGB plot (the range int 0..255 is represented as float 0..1.0). The values that fall outside the range are moved to one of the dynamic range boundaries (set equal 0.0 or 1.0). This operation does not keep quantitative information, but allows to substantially improve the visual presentation of data if its values are in narrow range or the data contain visible background noise.
- A button 'Deselect All' is added to Image Selection tool in 2D Plot tab. The logic of operation of 'Select All' and 'Deselect All' buttons is more appropriate now.