### PR TITLE
Fix: crashing while working with data from incomplete experiment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 - flake8
 - |
   if [ $BUILD_DOCS ]; then
-    pip install -r docs-requirements.txt
+    pip install -r requirements-docs.txt
     set -e  # If any of the following steps fail, just stop at that point.
     make -C docs html  # Build the documentation.
     doctr deploy --built-docs docs/_build/html .  # Publish the documentation.

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,7 +1,0 @@
-doctr
-ipython
-ipywidgets
-matplotlib
-numpydoc
-sphinx==1.6.7
-sphinx_rtd_theme

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -502,7 +502,7 @@ class DrawImageAdvanced(Atom):
                     high_limit += dv
                     low_limit -= dv
 
-                if scatter_show_local is not True:
+                if not scatter_show_local:
                     if grid_interpolate_local:
                         data_dict, _, _ = grid_interpolate(data_dict,
                                                            self.data_dict['positions']['x_pos'],
@@ -554,7 +554,7 @@ class DrawImageAdvanced(Atom):
                 if maxz <= 1e-30:
                     maxz = 1
 
-                if scatter_show_local is not True:
+                if not scatter_show_local:
                     if grid_interpolate_local:
                         data_dict, _, _ = grid_interpolate(data_dict,
                                                            self.data_dict['positions']['x_pos'],

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -329,9 +329,10 @@ class DrawImageAdvanced(Atom):
         if 'positions' in self.data_dict.keys():
             positions_data_available = True
 
-        # Create local copies of self.pixel_or_pos and self.scatter_show
+        # Create local copies of self.pixel_or_pos, self.scatter_show and self.grid_interpolate
         pixel_or_pos_local = self.pixel_or_pos
         scatter_show_local = self.scatter_show
+        grid_interpolate_local = self.grid_interpolate
 
         # Disable plotting vs x-y coordinates if 'positions' data is not available
         if not positions_data_available:
@@ -341,7 +342,9 @@ class DrawImageAdvanced(Atom):
             if scatter_show_local:
                 scatter_show_local = False  # Switch to plotting vs. pixel number
                 logger.error("'Positions' data is not available. Scatter plot is disabled.")
-
+            if grid_interpolate_local:
+                grid_interpolate_local = False  # Switch to plotting vs. pixel number
+                logger.error("'Positions' data is not available. Interpolation is disabled.")
 
         low_lim = 1e-4  # define the low limit for log image
         plot_interp = 'Nearest'
@@ -500,7 +503,7 @@ class DrawImageAdvanced(Atom):
                     low_limit -= dv
 
                 if scatter_show_local is not True:
-                    if self.grid_interpolate:
+                    if grid_interpolate_local:
                         data_dict, _, _ = grid_interpolate(data_dict,
                                                            self.data_dict['positions']['x_pos'],
                                                            self.data_dict['positions']['y_pos'])
@@ -552,7 +555,7 @@ class DrawImageAdvanced(Atom):
                     maxz = 1
 
                 if scatter_show_local is not True:
-                    if self.grid_interpolate:
+                    if grid_interpolate_local:
                         data_dict, _, _ = grid_interpolate(data_dict,
                                                            self.data_dict['positions']['x_pos'],
                                                            self.data_dict['positions']['y_pos'])

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -321,6 +321,28 @@ class DrawImageAdvanced(Atom):
         stat_temp = self.get_activated_num()
         stat_temp = OrderedDict(sorted(six.iteritems(stat_temp), key=lambda x: x[0]))
 
+        # Check if positions data is available. Positions data may be unavailable
+        # (not recorded in HDF5 file) if experiment is has not been completed.
+        # While the data from the completed part of experiment may still be used,
+        # plotting vs. x-y or scatter plot may not be displayed.
+        positions_data_available = False
+        if 'positions' in self.data_dict.keys():
+            positions_data_available = True
+
+        # Create local copies of self.pixel_or_pos and self.scatter_show
+        pixel_or_pos_local = self.pixel_or_pos
+        scatter_show_local = self.scatter_show
+
+        # Disable plotting vs x-y coordinates if 'positions' data is not available
+        if not positions_data_available:
+            if pixel_or_pos_local:
+                pixel_or_pos_local = 0  # Switch to plotting vs. pixel number
+                logger.error("'Positions' data is not available. Plotting vs. x-y coordinates is disabled")
+            if scatter_show_local:
+                scatter_show_local = False  # Switch to plotting vs. pixel number
+                logger.error("'Positions' data is not available. Scatter plot is disabled.")
+
+
         low_lim = 1e-4  # define the low limit for log image
         plot_interp = 'Nearest'
 
@@ -421,7 +443,7 @@ class DrawImageAdvanced(Atom):
                                                  data_name=k,
                                                  name_not_scalable=self.name_not_scalable)
 
-            if self.pixel_or_pos or self.scatter_show:
+            if pixel_or_pos_local or scatter_show_local:
 
                 # xd_min, xd_max, yd_min, yd_max = min(self.x_pos), max(self.x_pos),
                 #     min(self.y_pos), max(self.y_pos)
@@ -477,7 +499,7 @@ class DrawImageAdvanced(Atom):
                     high_limit += dv
                     low_limit -= dv
 
-                if self.scatter_show is not True:
+                if scatter_show_local is not True:
                     if self.grid_interpolate:
                         data_dict, _, _ = grid_interpolate(data_dict,
                                                            self.data_dict['positions']['x_pos'],
@@ -529,7 +551,7 @@ class DrawImageAdvanced(Atom):
                 if maxz <= 1e-30:
                     maxz = 1
 
-                if self.scatter_show is not True:
+                if scatter_show_local is not True:
                     if self.grid_interpolate:
                         data_dict, _, _ = grid_interpolate(data_dict,
                                                            self.data_dict['positions']['x_pos'],

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -519,7 +519,7 @@ def map_data2D_srx(runid, fpath,
                                 interp_list = (v.data[n][-1] - v.data[n][-3]) / 2 * \
                                     np.arange(1, len_diff + 1) + v.data[n][-1]
                                 data[n][m, min_len:datashape[1]] = interp_list
-                    fluor_len = v.data['fluor'].shape[0]
+                    fluor_len = v.data[detector_field].shape[0]
                     if m > 0 and not (m % 10):
                         print(f"Processed {m} of {n_scan_lines_total} lines ...")
                     # print(f"m = {m} Data shape {v.data['fluor'].shape} - {v.data['fluor'].shape[1] }")
@@ -527,11 +527,11 @@ def map_data2D_srx(runid, fpath,
                     if create_each_det is False:
                         for i in range(num_det):
                             # in case the data length in each line is different
-                            new_data['det_sum'][m, :fluor_len, :] += v.data['fluor'][:, i, :]
+                            new_data['det_sum'][m, :fluor_len, :] += v.data[detector_field][:, i, :]
                     else:
                         for i in range(num_det):
                             # in case the data length in each line is different
-                            new_data['det'+str(i+1)][m, :fluor_len, :] = v.data['fluor'][:, i, :]
+                            new_data['det'+str(i+1)][m, :fluor_len, :] = v.data[detector_field][:, i, :]
 
             # If the detector field does not exist, then try the next one from the list
             if not detector_field_exists:

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -636,7 +636,7 @@ def map_data2D_srx(runid, fpath,
                     #   will hold, but the last line of x-coordinates will be filleds with
                     #   zeros, which will create a mess if data is plotted with PyXRF
                     #   To fix the problem, fill the last line with values from the previous line
-                    x_pos[x_pos.shape[0] - 1, :] = x_pos[x_pos.shape[0] - 2, :]
+                    x_pos[-1, :] = x_pos[-2, :]
 
                 # The following condition check is left from the existing code. It is still checking
                 #   for the case if 0 lines were scanned.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,7 @@
+doctr
+ipython
+ipywidgets
+matplotlib
+numpydoc
+sphinx==1.6.7
+sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ matplotlib
 numpy
 pandas
 pillow
-pyqt5
+pyqt5<5.11
 requests
 scipy
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ h5py
 lmfit
 matplotlib
 numpy
-pillow
 pandas
+pillow
+pyqt5
 requests
 scipy
 six
-scikit-beam
 scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+atom
+enaml
+h5py
+lmfit
+matplotlib
+numpy
+pillow
+pandas
+requests
+scipy
+six
+scikit-beam
+scikit-image

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from setuptools import find_packages, setup
+from setuptools import setup
 
 import versioneer
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 from __future__ import (absolute_import, division, print_function)
 
-# import sys
-# import warnings
-# import numpy as np
 import versioneer
 
 try:
@@ -14,22 +11,28 @@ except ImportError:
     except ImportError:
         from distutils.core import setup
 
-# from distutils.core import setup
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
+requirements = ['setuptools'] + requirements
 
 setup(
     name='pyxrf',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     author='Brookhaven National Laboratory',
+    author_email='some_email@bnl.gov',
+    url='https://github.com/NSLS-II/PyXRF',
     packages=['pyxrf', 'pyxrf.model', 'pyxrf.view', 'pyxrf.db_config', 'configs'],
     entry_points={'console_scripts': ['pyxrf = pyxrf.gui:run']},
     package_data={'pyxrf.view': ['*.enaml'], 'configs': ['*.json']},
     include_package_data=True,
-    install_requires=['setuptools'],
+    install_requires=requirements,
+    python_requires='>=3.6',
     license='BSD',
     classifiers=['Development Status :: 3 - Alpha',
                  "License :: OSI Approved :: BSD License",
-                 "Programming Language :: Python :: 2.7",
+                 "Programming Language :: Python :: 3.7",
                  "Topic :: Software Development :: Libraries",
                  "Intended Audience :: Science/Research"]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,7 @@
 #!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function)
+from setuptools import find_packages, setup
 
 import versioneer
-
-try:
-    from setuptools import setup
-except ImportError:
-    try:
-        from setuptools.core import setup
-    except ImportError:
-        from distutils.core import setup
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
@@ -21,7 +13,6 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     author='Brookhaven National Laboratory',
-    author_email='some_email@bnl.gov',
     url='https://github.com/NSLS-II/PyXRF',
     packages=['pyxrf', 'pyxrf.model', 'pyxrf.view', 'pyxrf.db_config', 'configs'],
     entry_points={'console_scripts': ['pyxrf = pyxrf.gui:run']},


### PR DESCRIPTION
Pull request fixes two problems:

- Program crashing while displaying .h5 file from incomplete experiment.

  Generated HDF5 file from an experiment that was interrupted does not have 'positions' dataset. Attempt to plot data vs x,y coordinates crashes the program. Plotting functions (2D plot and RGB plot) were modified to prevent crashing. Modified functions disable all plotting and interpolation features that use x,y coordinates if 'positions' dataset is not available.

- Artificially generating x,y coordinates for 'positions' in case if the experiment is incomplete. 

  This is addition to the first modification and represents more permanent fix for the problem. If the dataset is incomplete (which periodically happens on the beamlines), the `make_hdf` function generates missing values of x and y coordinates and creates 'positions' dataset, which allows full functionality of data analysis using PyXRF.