### PR TITLE
Feature: updated tools for manual selection of element excitation spectral lines

### DIFF
--- a/configs/tes_pv_config.json
+++ b/configs/tes_pv_config.json
@@ -3,7 +3,7 @@
     "xrf_flyscan_detector_fields": {
         "fluor": "xs"
     },
-    "pos_list": ["stage_x", "stage_y", "stage_z"],
-    "scaler_list": ["Internal Clock", "I0", "It", "fbratio"],
+    "pos_list": ["x_centers", "y_centers", "z_centers"],
+    "scaler_list": ["dwell_time", "I0", "It", "fbratio"],
     "base_value": [0]
 }

--- a/configs/tes_pv_config.json
+++ b/configs/tes_pv_config.json
@@ -1,0 +1,9 @@
+{
+    "beamline": "TES",
+    "xrf_flyscan_detector_fields": {
+        "fluor": "xs"
+    },
+    "pos_list": ["stage_x", "stage_y", "stage_z"],
+    "scaler_list": ["Internal Clock", "I0", "It", "fbratio"],
+    "base_value": [0]
+}

--- a/pyxrf/db_config/tes_db_config.py
+++ b/pyxrf/db_config/tes_db_config.py
@@ -1,0 +1,23 @@
+from databroker._core import register_builtin_handlers
+
+#  srx detector, to be moved to filestore
+# from databroker.assets.handlers import Xspress3HDF5Handler
+from databroker.assets.handlers import HandlerBase
+
+
+db = Broker.named('tes')
+register_builtin_handlers(db.reg)
+
+
+class BulkXSPRESS(HandlerBase):
+    HANDLER_NAME = 'XPS3_FLY'
+
+    def __init__(self, resource_fn):
+        self._handle = h5py.File(resource_fn, 'r')
+
+    def __call__(self):
+        return self._handle['entry/instrument/detector/data'][:]
+
+
+db.reg.register_handler(BulkXSPRESS.HANDLER_NAME, BulkXSPRESS,
+                        overwrite=True)

--- a/pyxrf/db_config/tes_db_config.py
+++ b/pyxrf/db_config/tes_db_config.py
@@ -1,3 +1,5 @@
+import h5py
+from databroker import Broker
 from databroker._core import register_builtin_handlers
 
 #  srx detector, to be moved to filestore

--- a/pyxrf/gui.py
+++ b/pyxrf/gui.py
@@ -69,7 +69,7 @@ def run():
     defaults = get_defaults()
     io_model = FileIOModel(**defaults)
     param_model = GuessParamModel(**defaults)
-    plot_model = LinePlotModel()
+    plot_model = LinePlotModel(param_model=param_model)
     fit_model = Fit1D(**defaults)
     setting_model = SettingModel(**defaults)
     img_model_adv = DrawImageAdvanced()

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -100,8 +100,10 @@ class DrawImageAdvanced(Atom):
     def __init__(self):
         self.fig = plt.figure(figsize=(3, 2))
         matplotlib.rcParams['axes.formatter.useoffset'] = True
+
+        # Do not apply scaler norm on following data
         self.name_not_scalable = ['r2_adjust', 'alive', 'dead', 'elapsed_time', 'scaler_alive',
-                                  'i0_time', 'time', 'time_diff']  # do not apply scaler norm on those data
+                                  'i0_time', 'time', 'time_diff', 'dwell_time']
 
     def data_dict_update(self, change):
         """

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -124,6 +124,15 @@ class ElementController(object):
     def delete_all(self):
         self.element_dict.clear()
 
+    def is_element_in_list(self, k):
+        """
+        Check if element 'k' is in the list of selected elements
+        """
+        if k in self.element_dict.keys():
+            return True
+        else:
+            return False
+
     def get_element_list(self):
         current_elements = [v for v
                             in six.iterkeys(self.element_dict)

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -984,4 +984,3 @@ def update_param_from_element(param, element_list):
     # to create full param dict, for GUI only
     param_new = create_full_dict(param_new, fit_strategy_list)
     return param_new
-

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -672,7 +672,7 @@ class GuessParamModel(Atom):
 
         if include_user_peaks:
             userpeak_list = ['Userpeak' + str(i) for i in range(1, 11)]  # 10 users peak
-            items = items + userpeak_list
+            items += userpeak_list
 
         return items
 

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -17,6 +17,7 @@ from skbeam.core.fitting.xrf_model import (ParamController,
                                            compute_escape_peak, trim,
                                            construct_linear_model,
                                            linear_spectrum_fitting)
+from skbeam.core.fitting.xrf_model import (K_LINE, L_LINE, M_LINE)
 
 import logging
 logger = logging.getLogger()
@@ -237,7 +238,6 @@ class GuessParamModel(Atom):
     # total_m = Dict()
     # total_pileup = Dict()
     e_name = Str()        # Element line name selected in combo box
-    e_name_index = Int(0)  # The index of element line name selected in combo box
     add_element_intensity = Float(1000.0)
     element_list = List()
     # data_sets = Typed(OrderedDict)
@@ -664,6 +664,18 @@ class GuessParamModel(Atom):
         #     else:
         #         self.total_y[k] = self.EC.element_dict[k].spectrum
 
+    def get_user_peak_list(self, *, include_user_peaks=False):
+        """
+        Returns the list of element emission peaks
+        """
+        items = K_LINE + L_LINE + M_LINE
+
+        if include_user_peaks:
+            userpeak_list = ['Userpeak' + str(i) for i in range(1, 11)]  # 10 users peak
+            items = items + userpeak_list
+
+        return items
+
 
 def save_as(file_path, data):
     """
@@ -972,3 +984,4 @@ def update_param_from_element(param, element_list):
     # to create full param dict, for GUI only
     param_new = create_full_dict(param_new, fit_strategy_list)
     return param_new
+

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -236,7 +236,8 @@ class GuessParamModel(Atom):
     # total_l = Dict()
     # total_m = Dict()
     # total_pileup = Dict()
-    e_name = Str()
+    e_name = Str()        # Element line name selected in combo box
+    e_name_index = Int(0)  # The index of element line name selected in combo box
     add_element_intensity = Float(1000.0)
     element_list = List()
     # data_sets = Typed(OrderedDict)
@@ -511,7 +512,7 @@ class GuessParamModel(Atom):
                                                        elemental_lines=[e_name],
                                                        default_area=default_area)
             energy_float = float(get_energy(self.pileup_data['element1'])) + \
-                           float(get_energy(self.pileup_data['element2']))
+                float(get_energy(self.pileup_data['element2']))
             energy = f"{energy_float:.4f}"
 
             ratio_v = self.pileup_data['intensity'] / np.max(data_out[e_name])

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -487,7 +487,7 @@ class LinePlotModel(Atom):
         Parameters
         ----------
 
-        element_id : Int
+        element_id : int
             The number of the element emission line in the list
 
         data : ndarray or None
@@ -510,7 +510,7 @@ class LinePlotModel(Atom):
     def _set_allow_remove_eline(self, *, element_id, data):
         """
         Sets the flag, which enables/disables the controls
-        for manually removing element emission line
+        for manually removing an element emission line.
 
         Parameters
         ----------
@@ -534,13 +534,13 @@ class LinePlotModel(Atom):
     def _set_allow_select_elines(self, data):
         """
         Sets the flag, which enables/disables the controls
-        for manual selection of element emission line.
+        for manual selection of an element emission line.
         The selected line may be added or removed.
 
         Parameters
         ----------
 
-        element_id : Int
+        element_id : int
             The number of the element emission line in the list
 
         data : ndarray or None
@@ -553,7 +553,7 @@ class LinePlotModel(Atom):
 
     def is_line_in_selected_list(self, n_id, *, include_user_peaks=False):
         """
-        Checks if the line with ID 'n_id' is in the list of
+        Checks if the line with ID ``n_id`` is in the list of
         selected element lines.
         Used to enable/disable 'Add Line' and 'Remove Line' buttons.
 
@@ -562,7 +562,7 @@ class LinePlotModel(Atom):
 
         n_id : Int
             index of the element emission line in the list
-            (often equal to 'self.element_id')
+            (often equal to ``self.element_id``)
 
         Returns True if the element line
         is in the list of selected lines. False otherwise.
@@ -580,7 +580,7 @@ class LinePlotModel(Atom):
 
     def is_element_line_id_valid(self, n_id, *, include_user_peaks=False):
         """
-        Checks if ID ('n_id') of the element emission line is valid,
+        Checks if ID (``n_id``) of the element emission line is valid,
         i.e. the name of the line may be obtained by using the ID.
 
         Parameters
@@ -605,18 +605,18 @@ class LinePlotModel(Atom):
 
     def get_element_line_name_by_id(self, n_id, *, include_user_peaks=False):
         """
-        Retrievs the name of the element emission line from its ID
+        Retrieves the name of the element emission line from its ID
         (the number in the list). The lines are numbered starting with 1.
         If the ID is invalid, the function returns None.
 
         Parameters
         ----------
 
-        n_id : Int
+        n_id : int
             index of the element emission line in the list
             (often equal to 'self.element_id')
 
-        Returns the line name (Str). If the name can not be retrieve, then
+        Returns the line name (str). If the name can not be retrieved, then
         the function returns None.
         """
         if n_id < 1:
@@ -858,7 +858,7 @@ class LinePlotModel(Atom):
                     # The estimated peak intensity is the difference:
                     intensity = in_raw - in_fit
 
-                    # The following step is questionable. We assign some reasonable small number.
+                    # The following step is questionable. We assign some reasonably small number.
                     #   The desired value can always be manually entered
                     if intensity < 0.0:
                         intensity = abs(in_raw / 100)

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -17,6 +17,8 @@ from skbeam.core.fitting.xrf_model import (K_TRANSITIONS, L_TRANSITIONS, M_TRANS
 
 from skbeam.fluorescence import XrfElement as Element
 
+from .guessparam import GuessParamModel
+
 import logging
 logger = logging.getLogger()
 
@@ -75,6 +77,8 @@ class LinePlotModel(Atom):
         max value of data array
     incident_energy : float
         in KeV
+    param_model : Typed(object)
+        Reference to GuessParamModel object
     """
     data = Typed(object)  # Typed(np.ndarray)
     exp_data_label = Str('experiment')
@@ -117,6 +121,10 @@ class LinePlotModel(Atom):
     show_fit_opt = Bool(False)
     # fit_all = Typed(object)
 
+    allow_add_eline = Bool(False)
+    allow_remove_eline = Bool(False)
+    allow_select_elines = Bool(False)
+
     plot_style = Dict()
 
     roi_plot_dict = Dict()
@@ -137,7 +145,16 @@ class LinePlotModel(Atom):
     # data_dict = Dict()
     # roi_result = Dict()
 
-    def __init__(self):
+    # Reference to GuessParamModel object
+    param_model = Typed(object)
+
+    def __init__(self, param_model):
+
+        # Reference to GuessParamModel object
+        self.param_model = param_model
+
+        self.data = None
+
         self._fig = plt.figure(figsize=(3, 2))
         self._ax = self._fig.add_subplot(111)
         try:
@@ -196,6 +213,9 @@ class LinePlotModel(Atom):
         self.plot_exp_opt = False   # exp data for fitting
         self.show_exp_opt = False   # all exp data from different channels
         self.show_fit_opt = False
+
+        # Reset currently selected element_id (mostly to reset GUI elements)
+        self.element_id = 0
 
     def _update_canvas(self):
         self._ax.legend(loc=2)
@@ -304,20 +324,80 @@ class LinePlotModel(Atom):
 
         self._update_ylimit()
         self.log_linear_plot()
+
+        self._set_eline_select_controls()
+
+        # _show_hide_exp_plot is called to show or hide current plot based
+        #           on the state of _show_exp_opt flag
+        self._show_hide_exp_plot(self.show_exp_opt)
+        self.print_status("Function: exp_data_update")
+
+
+    def _show_hide_exp_plot(self, plot_show):
+
+        if self.data is None:
+            return
+
+        if plot_show:
+            self.plot_exp_obj.set_visible(True)
+            lab = self.plot_exp_obj.get_label()
+            self.plot_exp_obj.set_label(lab.strip('_'))
+        else:
+            self.plot_exp_obj.set_visible(False)
+            lab = self.plot_exp_obj.get_label()
+            self.plot_exp_obj.set_label('_' + lab)
+
         self._update_canvas()
 
     @observe('plot_exp_opt')
     def _new_exp_plot_opt(self, change):
+
+        if self.data is None:
+            return
+
         if change['type'] != 'create':
             if change['value']:
-                self.plot_exp_obj.set_visible(True)
-                lab = self.plot_exp_obj.get_label()
-                self.plot_exp_obj.set_label(lab.strip('_'))
-            else:
-                self.plot_exp_obj.set_visible(False)
-                lab = self.plot_exp_obj.get_label()
-                self.plot_exp_obj.set_label('_' + lab)
+                self.plot_experiment()
+            # _show_hide_exp_plot is already called inside 'plot_experiment()',
+            #    but visibility flag was not used correctly. So we need to
+            #    call it again.
+            self._show_hide_exp_plot(change['value'])
+            self._set_eline_select_controls(exp_plot_visible=change['value'])
 
+    @observe('show_exp_opt')
+    def _update_exp(self, change):
+        if change['type'] != 'create':
+            if change['value']:
+                if len(self.plot_exp_list):
+                    for v in self.plot_exp_list:
+                        v.set_visible(True)
+                        lab = v.get_label()
+                        if lab != '_nolegend_':
+                            v.set_label(lab.strip('_'))
+            else:
+                if len(self.plot_exp_list):
+                    for v in self.plot_exp_list:
+                        v.set_visible(False)
+                        lab = v.get_label()
+                        if lab != '_nolegend_':
+                            v.set_label('_' + lab)
+            self._update_canvas()
+
+    @observe('show_fit_opt')
+    def _update_fit(self, change):
+        if change['type'] != 'create':
+            if change['value']:
+                for v in self.plot_fit_obj:
+                    v.set_visible(True)
+                    lab = v.get_label()
+                    if lab != '_nolegend_':
+                        v.set_label(lab.strip('_'))
+            else:
+                for v in self.plot_fit_obj:
+                    v.set_visible(False)
+                    lab = v.get_label()
+                    if lab != '_nolegend_':
+                        v.set_label('_' + lab)
             self._update_canvas()
 
     def plot_experiment(self):
@@ -331,6 +411,8 @@ class LinePlotModel(Atom):
 
         data_arr = np.asarray(self.data)
         self.exp_data_update({'value': data_arr})
+        self.print_status("Function: plot_experiment")
+
 
     def plot_multi_exp_data(self):
         while(len(self.plot_exp_list)):
@@ -365,24 +447,6 @@ class LinePlotModel(Atom):
         self.log_linear_plot()
         self._update_canvas()
 
-    @observe('show_exp_opt')
-    def _update_exp(self, change):
-        if change['type'] != 'create':
-            if change['value']:
-                if len(self.plot_exp_list):
-                    for v in self.plot_exp_list:
-                        v.set_visible(True)
-                        lab = v.get_label()
-                        if lab != '_nolegend_':
-                            v.set_label(lab.strip('_'))
-            else:
-                if len(self.plot_exp_list):
-                    for v in self.plot_exp_list:
-                        v.set_visible(False)
-                        lab = v.get_label()
-                        if lab != '_nolegend_':
-                            v.set_label('_' + lab)
-            self._update_canvas()
 
     def plot_emission_line(self):
         """
@@ -410,12 +474,95 @@ class LinePlotModel(Atom):
                                            linewidth=self.plot_style['emission_line']['linewidth'])
                     self.eline_obj.append(eline)
 
+    def _set_eline_select_controls(self, *, element_id=None, exp_plot_visible=None, data="use_self_data"):
+        if element_id is None:
+            element_id = self.element_id
+        if exp_plot_visible is None:
+            exp_plot_visible = self.plot_exp_opt
+        if data == "use_self_data":
+            data = self.data
+        self._set_allow_add_eline(element_id=element_id, exp_plot_visible=exp_plot_visible, data=data)
+        self._set_allow_remove_eline(element_id=element_id, exp_plot_visible=exp_plot_visible, data=data)
+        self._set_allow_select_elines(exp_plot_visible=exp_plot_visible, data=data)
+
+
+    def _set_allow_add_eline(self, *, element_id, exp_plot_visible, data):
+        flag = True
+        if data is None:
+            flag = False
+        if not self.is_element_line_id_valid(element_id):
+            flag = False
+        if self.is_line_in_selected_list(element_id):
+            flag = False
+        if not exp_plot_visible:
+            flag = False
+        self.allow_add_eline = flag
+
+    def _set_allow_remove_eline(self, *, element_id, exp_plot_visible, data):
+        flag = False
+        if data is None:
+            flag = False
+        if self.is_line_in_selected_list(element_id):
+            flag = True
+        if not exp_plot_visible:
+            flag = False
+        self.allow_remove_eline = flag
+
+    def _set_allow_select_elines(self, exp_plot_visible, data):
+        flag = True
+        if data is None:
+            flag = False
+        if not exp_plot_visible:
+            flag = False
+        self.allow_select_elines = flag
+
+
+    def is_line_in_selected_list(self, n_id):
+        """
+        Returns True if the element line (self.element_id)
+        is in the list of selected element lines. False otherwise.
+        The function is supposed to be called with
+        n_id = self.element_id
+        Used to enable/disable 'Add Line' and 'Remove Line' buttons.
+        """
+
+        ename = self.get_element_line_name_by_id(n_id)
+
+        if ename is None:
+            return False
+
+        if self.param_model.EC.is_element_in_list(ename):
+            return True
+        else:
+            return False
+
+    def is_element_line_id_valid(self, n_id):
+        """
+        Returns True if the current element line index is valid
+        (will return valid element line name) and may be used
+        to add an element line. (Used to enable/disable 'Add line' button).
+        The function is supposed to be called with
+        n_id = self.element_id
+        """
+
+        ename = self.get_element_line_name_by_id(n_id)
+
+        if ename is None:
+            return False
+        else:
+            return True
+
     def get_element_line_name_by_id(self, n_id):
         """
         Returns element emission line name by ID (number in the list)
           The ID is produced by the element selection combo box in
           the
         """
+        if n_id < 1:
+            # Elements are numbered starting with 1. Element #0 does not exist.
+            #   (Element #0 means that no element is selected)
+            return None
+
         total_list = K_LINE + L_LINE + M_LINE
         try:
             ename = total_list[n_id-1]
@@ -423,8 +570,21 @@ class LinePlotModel(Atom):
             ename = None
         return ename
 
+    def print_status(self, message):
+        print(f"*** {message}")
+        print(f"    show_exp_opt: {self.show_exp_opt}")
+        print(f"    show_fit_opt: {self.show_fit_opt}")
+        print(f"    plot_exp_opt: {self.plot_exp_opt}")
+        print(f"    {self.allow_add_eline} {self.allow_remove_eline} {self.allow_select_elines}")
+
     @observe('element_id')
     def set_element(self, change):
+
+        self.print_status("Function: set_element (observe 'element_id')")
+        print(f"    element_id = {change['value']}")
+
+        self._set_eline_select_controls(element_id=change['value'])
+
         if change['value'] == 0:
             while(len(self.eline_obj)):
                 self.eline_obj.pop().remove()
@@ -795,20 +955,3 @@ class LinePlotModel(Atom):
                 pass
 
         # self._update_canvas()
-
-    @observe('show_fit_opt')
-    def _update_fit(self, change):
-        if change['type'] != 'create':
-            if change['value']:
-                for v in self.plot_fit_obj:
-                    v.set_visible(True)
-                    lab = v.get_label()
-                    if lab != '_nolegend_':
-                        v.set_label(lab.strip('_'))
-            else:
-                for v in self.plot_fit_obj:
-                    v.set_visible(False)
-                    lab = v.get_label()
-                    if lab != '_nolegend_':
-                        v.set_label('_' + lab)
-            self._update_canvas()

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -482,7 +482,7 @@ class LinePlotModel(Atom):
     def _set_allow_add_eline(self, *, element_id, data):
         """
         Sets the flag, which enables/disables the controls
-        for manually adding element emission line
+        for manually adding an element emission line.
 
         Parameters
         ----------

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -711,7 +711,7 @@ def map_data2D_tes(runid, fpath,
     create_each_det: bool, optional
         Do not create data for each detector if data size is too large,
         if set as False. This will slow down the speed of creating an hdf5 file
-        with large data size. srx beamline only.
+        with large data size. SRX beamline only.
     output_to_file : bool, optional
         save data to hdf5 file if True
 

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -695,7 +695,7 @@ def map_data2D_tes(runid, fpath,
     Transfer the data from databroker into a correct format following the
     shape of 2D scan.
     This function is used at TES beamline for step scan.
-    Save the new data dictionary to hdf file if needed.
+    Save the new data dictionary to hdf5 file if needed.
 
     .. note:: It is recommended to read data from databroker into memory
     directly, instead of saving to files. This is ongoing work.

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -710,7 +710,7 @@ def map_data2D_tes(runid, fpath,
         path to save hdf file
     create_each_det: bool, optional
         Do not create data for each detector if data size is too large,
-        if set as false. This will slow down the speed of creating hdf file
+        if set as False. This will slow down the speed of creating an hdf5 file
         with large data size. srx beamline only.
     output_to_file : bool, optional
         save data to hdf5 file if True

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -717,6 +717,18 @@ def map_data2D_tes(runid, fpath,
     dict of data in 2D format matching x,y scanning positions
     """
 
+    hdr = db[runid]
+    start_doc = hdr['start']
+
+    # Load configuration file
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    config_file = 'tes_pv_config.json'
+    config_path = sep_v.join(current_dir.split(sep_v)[:-2] + ['configs', config_file])
+    with open(config_path, 'r') as json_data:
+        config_data = json.load(json_data)
+
+
+
 
     return {}
 

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -709,7 +709,7 @@ def map_data2D_tes(runid, fpath,
     fpath: str
         path to save hdf file
     create_each_det: bool, optional
-        Do not create data for each detector is data size is too large,
+        Do not create data for each detector if data size is too large,
         if set as false. This will slow down the speed of creating hdf file
         with large data size. srx beamline only.
     output_to_file : bool, optional

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -29,6 +29,8 @@ try:
         from pyxrf.db_config.srx_db_config import db
     elif beamline_name == 'XFM':
         from pyxrf.db_config.xfm_db_config import db
+    elif beamline_name == 'TES':
+        from pyxrf.db_config.tes_db_config import db
     else:
         db = None
         db_analysis = None
@@ -132,6 +134,10 @@ def fetch_data_from_db(runid, fpath=None,
                               num_end_lines_excluded=num_end_lines_excluded)
     elif hdr.start.beamline_id == 'XFM':
         data = map_data2D_xfm(runid, fpath,
+                              create_each_det=create_each_det,
+                              output_to_file=output_to_file)
+    elif hdr.start.beamline_id == 'TES':
+        data = map_data2D_tes(runid, fpath,
                               create_each_det=create_each_det,
                               output_to_file=output_to_file)
     else:
@@ -679,6 +685,40 @@ def map_data2D_srx(runid, fpath,
             print(".")
 
         return new_data
+
+
+def map_data2D_tes(runid, fpath,
+                   create_each_det=False,
+                   output_to_file=True):
+    """
+    Transfer the data from databroker into a correct format following the
+    shape of 2D scan.
+    This function is used at TES beamline for step scan.
+    Save the new data dictionary to hdf file if needed.
+
+    .. note:: It is recommended to read data from databroker into memory
+    directly, instead of saving to files. This is ongoing work.
+
+    Parameters
+    ----------
+    runid : int
+        id number for given run
+    fpath: str
+        path to save hdf file
+    create_each_det: bool, optional
+        Do not create data for each detector is data size is too large,
+        if set as false. This will slow down the speed of creating hdf file
+        with large data size. srx beamline only.
+    output_to_file : bool, optional
+        save data to hdf5 file if True
+
+    Returns
+    -------
+    dict of data in 2D format matching x,y scanning positions
+    """
+
+
+    return {}
 
 
 def map_data2D_xfm(runid, fpath,

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -697,7 +697,9 @@ def map_data2D_tes(runid, fpath,
     This function is used at TES beamline for step scan.
     Save the new data dictionary to hdf5 file if needed.
 
-    .. note:: It is recommended to read data from databroker into memory
+    .. note::
+    
+      It is recommended to read data from databroker into memory
     directly, instead of saving to files. This is ongoing work.
 
     Parameters

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -698,7 +698,7 @@ def map_data2D_tes(runid, fpath,
     Save the new data dictionary to hdf5 file if needed.
 
     .. note::
-    
+
       It is recommended to read data from databroker into memory
     directly, instead of saving to files. This is ongoing work.
 

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -34,7 +34,7 @@ except ImportError:
     databroker = None
 
 
-userpeak_list = ['Userpeak'+str(i) for i in range(1, 11)]  # 10 users peak
+# userpeak_list = ['Userpeak'+str(i) for i in range(1, 11)]  # 10 users peak
 
 enamldef FloatField(DefaultFloatField):
     submit_triggers = ['auto_sync'] #['return_pressed']
@@ -184,8 +184,9 @@ enamldef FitView(DockItem): fit_view:
                 ),
             ]
             ComboBox: cb_select:
-                items = ['Select Lines'] +\
-                        K_LINE + L_LINE + M_LINE + userpeak_list
+                #items = ['Select Lines'] +\
+                #        K_LINE + L_LINE + M_LINE + userpeak_list
+                items = ['Select Lines'] + param_model.get_user_peak_list(include_user_peaks=True)
                 index = 0
                 index := plot_model.element_id
                 enabled << plot_model.allow_select_elines
@@ -198,7 +199,7 @@ enamldef FitView(DockItem): fit_view:
 
             FloatField: intensity_fd:
                 value := param_model.add_element_intensity
-                maximum_size = 60
+                maximum_size = 80
                 enabled << (cb_select.index > 0) and plot_model.allow_add_eline
 
             PushButton: manual_add:

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -130,6 +130,9 @@ enamldef FitView(DockItem): fit_view:
                             plot_model.plot_fit(fit_model.cal_x, fit_model.cal_y,
                                                 fit_model.cal_spectrum,
                                                 fit_model.residual)
+
+                            plot_model.plot_exp_opt = False
+                            plot_model.plot_exp_opt = True
                             # For plotting purposes, otherwise plot will not update
                             plot_model.show_fit_opt = False
                             plot_model.show_fit_opt = True
@@ -321,6 +324,12 @@ enamldef FitView(DockItem): fit_view:
                                                         param_model.total_y,
                                                         param_model.auto_fit_all)
                                     # For plotting purposes, otherwise plot will not update
+                                    if plot_model.plot_exp_opt:
+                                        plot_model.plot_exp_opt = False
+                                        plot_model.plot_exp_opt = True
+                                    else:
+                                        plot_model.plot_exp_opt = True
+                                        plot_model.plot_exp_opt = False
                                     plot_model.show_fit_opt = False
                                     plot_model.show_fit_opt = True
                                     param_model.update_name_list()
@@ -451,8 +460,8 @@ enamldef FitView(DockItem): fit_view:
                         # update experimental plots
                         plot_model.parameters = fit_model.default_parameters
                         plot_model.plot_experiment()
-                        plot_model.plot_exp_opt = False
-                        plot_model.plot_exp_opt = True
+                        #plot_model.plot_exp_opt = False
+                        #plot_model.plot_exp_opt = True
 
                         # update autofit param
                         param_model.update_new_param(fit_model.default_parameters)
@@ -471,6 +480,12 @@ enamldef FitView(DockItem): fit_view:
                                             fit_model.cal_spectrum,
                                             fit_model.residual)
                         # For plotting purposes, otherwise plot will not update
+                        if plot_model.plot_exp_opt:
+                            plot_model.plot_exp_opt = False
+                            plot_model.plot_exp_opt = True
+                        else:
+                            plot_model.plot_exp_opt = True
+                            plot_model.plot_exp_opt = False
                         plot_model.show_fit_opt = False
                         plot_model.show_fit_opt = True
 
@@ -554,6 +569,8 @@ enamldef FitView(DockItem): fit_view:
                                             fit_model.residual)
 
                         # For plotting purposes, otherwise plot will not update
+                        plot_model.plot_exp_opt = False
+                        plot_model.plot_exp_opt = True
                         plot_model.show_fit_opt = False
                         plot_model.show_fit_opt = True
 
@@ -898,6 +915,9 @@ enamldef AutoFindElements(Window): auto_win:
                                     param_model.total_y,
                                     param_model.auto_fit_all)
 
+                # Show the summed spectrum used for fitting
+                plot_model.plot_exp_opt = False
+                plot_model.plot_exp_opt = True
                 # For plotting purposes, otherwise plot will not update
                 plot_model.show_fit_opt = False
                 plot_model.show_fit_opt = True
@@ -1456,6 +1476,13 @@ def apply_to_fit(param_model, plot_model,
                         param_model.auto_fit_all)
 
     # For plotting purposes, otherwise plot will not update
+
+    if plot_model.plot_exp_opt:
+        plot_model.plot_exp_opt = False
+        plot_model.plot_exp_opt = True
+    else:
+        plot_model.plot_exp_opt = True
+        plot_model.plot_exp_opt = False
     plot_model.show_fit_opt = False
     plot_model.show_fit_opt = True
 

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -470,6 +470,9 @@ enamldef FitView(DockItem): fit_view:
                         # calculate profile and plot
                         fit_model.get_profile()
 
+                        # Update displayed intensity of the selected peak
+                        plot_model.compute_manual_peak_intensity()
+
                         # update experimental plot with new calibration values
                         plot_model.plot_fit(fit_model.cal_x, fit_model.cal_y,
                                             fit_model.cal_spectrum,
@@ -577,6 +580,9 @@ enamldef FitView(DockItem): fit_view:
 
                         # update params for roi sum
                         setting_model.update_parameter(fit_model.param_dict)
+
+                        # Update displayed intensity of the selected peak
+                        plot_model.compute_manual_peak_intensity()
 
                     else:
 
@@ -909,6 +915,9 @@ enamldef AutoFindElements(Window): auto_win:
                 plot_model.plot_fit(param_model.prefit_x,
                                     param_model.total_y,
                                     param_model.auto_fit_all)
+
+                # Update displayed intensity of the selected peak
+                plot_model.compute_manual_peak_intensity()
 
                 # Show the summed spectrum used for fitting
                 plot_model.plot_exp_opt = False
@@ -1501,6 +1510,9 @@ def apply_to_fit(param_model, plot_model,
 
     # update params for roi sum
     setting_model.update_parameter(fit_model.param_dict)
+
+    # Update displayed intensity of the selected peak
+    plot_model.compute_manual_peak_intensity()
 
 
 def get_energy(name):

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -227,7 +227,7 @@ enamldef FitView(DockItem): fit_view:
 
             PushButton: pb_pileup:
                 text = 'Add Pileup Peaks'
-                enabled = True
+                enabled << cb_select.index > 0
                 checkable = True
                 checked := pileup_edit.visible
                 clicked ::

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -227,14 +227,14 @@ enamldef FitView(DockItem): fit_view:
 
             PushButton: pb_pileup:
                 text = 'Add Pileup Peaks'
-                enabled << cb_select.index > 0
-                checkable = True
-                checked := pileup_edit.visible
                 clicked ::
-                    if checked:
+                    # The following set of conditions is not complete, but sufficient
+                    if param_model.x0 is not None and param_model.y0 is not None:
                         pileup_edit.show()
                     else:
-                        pileup_edit.hide()
+                        btns = [DialogButton('Ok', 'accept')]
+                        # 'critical' shows MessageBox
+                        critical(self, 'ERROR', f'Experimental data is not loaded or initial spectrum fitting is not performed', btns)
 
             GroupBox: pre_fit:
                 padding = Box(2, 2, 2, 2)

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -203,27 +203,37 @@ enamldef FitView(DockItem): fit_view:
                 text = 'Add'
                 enabled << cb_select.index > 0
                 clicked ::
-
+                    pass
                     # The following set of conditions is not complete, but sufficient
-                    if param_model.x0 is not None and param_model.y0 is not None:
-
-                        param_model.manual_input()
-                        param_model.EC.update_peak_ratio()
-                        param_model.update_name_list()
-                        param_model.data_for_plot()
-
-                        plot_model.plot_fit(param_model.prefit_x,
-                                            param_model.total_y,
-                                            param_model.auto_fit_all)
-                        # For plotting purposes, otherwise plot will not update
-                        plot_model.show_fit_opt = False
-                        plot_model.show_fit_opt = True
-
-                    else:
+                    if param_model.x0 is None or param_model.y0 is None:
 
                         btns = [DialogButton('Ok', 'accept')]
                         # 'critical' shows MessageBox
                         critical(self, 'ERROR', f'Experimental data is not loaded or initial spectrum fitting is not performed', btns)
+
+                    else:
+
+                        peak_name = param_model.e_name
+
+                        if param_model.EC.is_element_in_list(peak_name):
+
+                            btns = [DialogButton('Ok', 'accept')]
+                            # 'critical' shows MessageBox
+                            critical(self, 'ERROR', f'Element emission line {peak_name} is already selected', btns)
+
+                        else:
+
+                            param_model.manual_input()
+                            param_model.EC.update_peak_ratio()
+                            param_model.update_name_list()
+                            param_model.data_for_plot()
+
+                            plot_model.plot_fit(param_model.prefit_x,
+                                                param_model.total_y,
+                                                param_model.auto_fit_all)
+                            # For plotting purposes, otherwise plot will not update
+                            plot_model.show_fit_opt = False
+                            plot_model.show_fit_opt = True
 
             PushButton: pb_pileup:
                 text = 'Add Pileup Peaks'
@@ -1385,8 +1395,7 @@ enamldef EditPileupPeak(Window): pileup_win:
     attr param_model
     attr plot_model
     destroy_on_close = False
-
-    #title = 'Pileup Peak Editor'
+    title = 'Add Pileup Peak'
     Container:
         Form:
             Label: e1:
@@ -1405,23 +1414,37 @@ enamldef EditPileupPeak(Window): pileup_win:
                 text = 'Add'
                 maximum_size = 60
                 clicked ::
-                    param_model.pileup_data['element1'] = fd1.text
-                    param_model.pileup_data['element2'] = fd2.text
-                    param_model.pileup_data['intensity'] = intensity_ff.value
+                    try:
+                        param_model.pileup_data['element1'] = fd1.text
+                        param_model.pileup_data['element2'] = fd2.text
+                        param_model.pileup_data['intensity'] = intensity_ff.value
 
-                    param_model.add_pileup()
-                    param_model.EC.update_peak_ratio()
-                    param_model.update_name_list()
-                    param_model.data_for_plot()
+                        peak_name = param_model.generate_pileup_peak_name()
+                        if not param_model.EC.is_element_in_list(peak_name):
 
-                    plot_model.plot_fit(param_model.prefit_x,
-                                        param_model.total_y,
-                                        param_model.auto_fit_all)
-                    # For plotting purposes, otherwise plot will not update
-                    plot_model.show_fit_opt = False
-                    plot_model.show_fit_opt = True
-                    pileup_win.close()
+                            param_model.add_pileup()
+                            param_model.EC.update_peak_ratio()
+                            param_model.update_name_list()
+                            param_model.data_for_plot()
 
+                            plot_model.plot_fit(param_model.prefit_x,
+                                                param_model.total_y,
+                                                param_model.auto_fit_all)
+                            # For plotting purposes, otherwise plot will not update
+                            plot_model.show_fit_opt = False
+                            plot_model.show_fit_opt = True
+                            pileup_win.close()
+
+                        else:
+
+                            btns = [DialogButton('Ok', 'accept')]
+                            # 'critical' shows MessageBox
+                            critical(self, 'ERROR', f'Element emission line {peak_name} is already selected', btns)
+
+                    except Exception:
+                        btns = [DialogButton('Ok', 'accept')]
+                        # 'critical' shows MessageBox
+                        critical(self, 'ERROR', f'Unknown element emission lines or non-positive peak intensity', btns)
 
 def set_low_bound(value, thresh_v=0.1):
     """

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -178,7 +178,7 @@ enamldef FitView(DockItem): fit_view:
             constraints = [
                 vbox(
                     hbox(cb_select, intensity_lb, intensity_fd,
-                         manual_add, spacer, pb_pileup),
+                         manual_add, manual_remove, spacer, pb_pileup),
                     pre_fit,
                     #hbox(saveas_btn, spacer),
                 ),
@@ -187,6 +187,8 @@ enamldef FitView(DockItem): fit_view:
                 items = ['Select Lines'] +\
                         K_LINE + L_LINE + M_LINE + userpeak_list
                 index = 0
+                index := plot_model.element_id
+                enabled << plot_model.allow_select_elines
                 index ::
                     if cb_select.index > 0:
                         param_model.e_name = cb_select.selected_item
@@ -197,13 +199,12 @@ enamldef FitView(DockItem): fit_view:
             FloatField: intensity_fd:
                 value := param_model.add_element_intensity
                 maximum_size = 60
-                enabled << cb_select.index > 0
+                enabled << (cb_select.index > 0) and plot_model.allow_add_eline
 
             PushButton: manual_add:
                 text = 'Add'
-                enabled << cb_select.index > 0
+                enabled << (cb_select.index > 0) and plot_model.allow_add_eline
                 clicked ::
-                    pass
                     # The following set of conditions is not complete, but sufficient
                     if param_model.x0 is None or param_model.y0 is None:
 
@@ -213,27 +214,15 @@ enamldef FitView(DockItem): fit_view:
 
                     else:
 
-                        peak_name = param_model.e_name
+                        plot_model.add_peak_manual()
+                        cb_select.set_focus()  # Return focus to the combo box
 
-                        if param_model.EC.is_element_in_list(peak_name):
-
-                            btns = [DialogButton('Ok', 'accept')]
-                            # 'critical' shows MessageBox
-                            critical(self, 'ERROR', f'Element emission line {peak_name} is already selected', btns)
-
-                        else:
-
-                            param_model.manual_input()
-                            param_model.EC.update_peak_ratio()
-                            param_model.update_name_list()
-                            param_model.data_for_plot()
-
-                            plot_model.plot_fit(param_model.prefit_x,
-                                                param_model.total_y,
-                                                param_model.auto_fit_all)
-                            # For plotting purposes, otherwise plot will not update
-                            plot_model.show_fit_opt = False
-                            plot_model.show_fit_opt = True
+            PushButton: manual_remove:
+                text = 'Remove'
+                enabled << (cb_select.index > 0) and plot_model.allow_remove_eline
+                clicked ::
+                    plot_model.remove_peak_manual(param_model.e_name)
+                    cb_select.set_focus()  # Return focus to the combo box
 
             PushButton: pb_pileup:
                 text = 'Add Pileup Peaks'
@@ -338,25 +327,7 @@ enamldef FitView(DockItem): fit_view:
                                 text = 'Del'
                                 maximum_size = 30
                                 clicked ::
-                                    param_model.EC.delete_item(loop_item)
-                                    #apply_to_fit(param_model, plot_model, fit_model)
-                                    param_model.EC.update_peak_ratio()
-                                    param_model.data_for_plot()
-
-                                    plot_model.plot_fit(param_model.prefit_x,
-                                                        param_model.total_y,
-                                                        param_model.auto_fit_all)
-                                    # For plotting purposes, otherwise plot will not update
-                                    if plot_model.plot_exp_opt:
-                                        plot_model.plot_exp_opt = False
-                                        plot_model.plot_exp_opt = True
-                                    else:
-                                        plot_model.plot_exp_opt = True
-                                        plot_model.plot_exp_opt = False
-                                    plot_model.show_fit_opt = False
-                                    plot_model.show_fit_opt = True
-                                    param_model.update_name_list()
-                                    #apply_to_fit(param_model, plot_model, fit_model, setting_model)
+                                    plot_model.remove_peak_manual(loop_item)
 
                             Container:
                                 padding = Box(2, 2, 2, 2)

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -200,11 +200,11 @@ enamldef FitView(DockItem): fit_view:
             FloatField: intensity_fd:
                 value := param_model.add_element_intensity
                 maximum_size = 80
-                enabled << (cb_select.index > 0) and plot_model.allow_add_eline
+                enabled << (cb_select.index > 0) and plot_model.allow_add_eline_fit
 
             PushButton: manual_add:
                 text = 'Add'
-                enabled << (cb_select.index > 0) and plot_model.allow_add_eline
+                enabled << (cb_select.index > 0) and plot_model.allow_add_eline_fit
                 clicked ::
                     # The following set of conditions is not complete, but sufficient
                     if param_model.x0 is None or param_model.y0 is None:
@@ -220,7 +220,7 @@ enamldef FitView(DockItem): fit_view:
 
             PushButton: manual_remove:
                 text = 'Remove'
-                enabled << (cb_select.index > 0) and plot_model.allow_remove_eline
+                enabled << (cb_select.index > 0) and plot_model.allow_remove_eline_fit
                 clicked ::
                     plot_model.remove_peak_manual(param_model.e_name)
                     cb_select.set_focus()  # Return focus to the combo box

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -193,24 +193,37 @@ enamldef FitView(DockItem): fit_view:
 
             Label: intensity_lb:
                 text = 'Peak Int'
+
             FloatField: intensity_fd:
                 value := param_model.add_element_intensity
                 maximum_size = 60
+                enabled << cb_select.index > 0
 
             PushButton: manual_add:
                 text = 'Add'
+                enabled << cb_select.index > 0
                 clicked ::
-                    param_model.manual_input()
-                    param_model.EC.update_peak_ratio()
-                    param_model.update_name_list()
-                    param_model.data_for_plot()
 
-                    plot_model.plot_fit(param_model.prefit_x,
-                                        param_model.total_y,
-                                        param_model.auto_fit_all)
-                    # For plotting purposes, otherwise plot will not update
-                    plot_model.show_fit_opt = False
-                    plot_model.show_fit_opt = True
+                    # The following set of conditions is not complete, but sufficient
+                    if param_model.x0 is not None and param_model.y0 is not None:
+
+                        param_model.manual_input()
+                        param_model.EC.update_peak_ratio()
+                        param_model.update_name_list()
+                        param_model.data_for_plot()
+
+                        plot_model.plot_fit(param_model.prefit_x,
+                                            param_model.total_y,
+                                            param_model.auto_fit_all)
+                        # For plotting purposes, otherwise plot will not update
+                        plot_model.show_fit_opt = False
+                        plot_model.show_fit_opt = True
+
+                    else:
+
+                        btns = [DialogButton('Ok', 'accept')]
+                        # 'critical' shows MessageBox
+                        critical(self, 'ERROR', f'Experimental data is not loaded or initial spectrum fitting is not performed', btns)
 
             PushButton: pb_pileup:
                 text = 'Add Pileup Peaks'

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -77,6 +77,7 @@ enamldef PlotMain(DockItem):
                     K_LINE + L_LINE + M_LINE
             index := plot_model.element_id
             index = 0
+
         PushButton: pb_print:
             text  ='Print'
             clicked ::

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -81,8 +81,10 @@ enamldef PlotMain(DockItem):
                 cbox2.set_focus()  # Return focus to the combo box
 
         ComboBox: cbox2:
-            items = ['<Display emission lines>'] +\
-                    K_LINE + L_LINE + M_LINE
+            #items = ['<Display emission lines>'] +\
+            #        K_LINE + L_LINE + M_LINE
+            items = ['<Display emission lines>'] + param_model.get_user_peak_list(include_user_peaks=False)
+
             index = 0
             index := plot_model.element_id
             enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -47,7 +47,7 @@ enamldef PlotMain(DockItem):
         constraints = [
             vbox(
                 hbox(plot_exp_btn, pb_plot_fit, spacer, pb_print),
-                hbox(cbox1, spacer, pb_eline, cbox2, checkb),
+                hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, cbox2, checkb),
                 canvas,
             ),
         ]
@@ -65,6 +65,12 @@ enamldef PlotMain(DockItem):
                     adjust_emission_line.show()
                 else:
                     adjust_emission_line.hide()
+
+        PushButton: add_eline:
+            text = 'Add line'
+
+        PushButton: remove_eline:
+            text = 'Remove line'
 
         ComboBox: cbox2:
             items = ['<Display emission lines>'] +\

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -68,15 +68,18 @@ enamldef PlotMain(DockItem):
 
         PushButton: add_eline:
             text = 'Add line'
+            enabled << plot_model.allow_add_eline
 
         PushButton: remove_eline:
             text = 'Remove line'
+            enabled << plot_model.allow_remove_eline
 
         ComboBox: cbox2:
             items = ['<Display emission lines>'] +\
                     K_LINE + L_LINE + M_LINE
             index := plot_model.element_id
             index = 0
+            enabled << plot_model.allow_select_elines
 
         PushButton: pb_print:
             text  ='Print'
@@ -86,13 +89,13 @@ enamldef PlotMain(DockItem):
         PushButton: plot_exp_btn:
             text = 'Plot Selected Exp. Data'
             checkable = True
-            checked << plot_model.plot_exp_opt
-            clicked ::
-                if checked:
-                    plot_model.plot_experiment()
-                    plot_model.plot_exp_opt = True
-                else:
-                    plot_model.plot_exp_opt = False
+            checked := plot_model.plot_exp_opt
+            #clicked ::
+            #    if checked:
+            #        plot_model.plot_experiment()
+            #        plot_model.plot_exp_opt = True
+            #    else:
+            #        plot_model.plot_exp_opt = False
 
         PushButton: pb_plot_fit:
             text = 'Plot Fit Result'

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -68,18 +68,27 @@ enamldef PlotMain(DockItem):
 
         PushButton: add_eline:
             text = 'Add line'
-            enabled << plot_model.allow_add_eline
+            enabled << plot_model.allow_add_eline and plot_model.plot_exp_opt
+            clicked ::
+                plot_model.add_peak_manual()
+                cbox2.set_focus()  # Return focus to the combo box
 
         PushButton: remove_eline:
             text = 'Remove line'
-            enabled << plot_model.allow_remove_eline
+            enabled << plot_model.allow_remove_eline and plot_model.plot_exp_opt
+            clicked ::
+                plot_model.remove_peak_manual(param_model.e_name)
+                cbox2.set_focus()  # Return focus to the combo box
 
         ComboBox: cbox2:
             items = ['<Display emission lines>'] +\
                     K_LINE + L_LINE + M_LINE
-            index := plot_model.element_id
             index = 0
-            enabled << plot_model.allow_select_elines
+            index := plot_model.element_id
+            enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt
+            index ::
+                if cbox2.index > 0:
+                    param_model.e_name = cbox2.selected_item
 
         PushButton: pb_print:
             text  ='Print'

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -118,6 +118,9 @@ enamldef PlotMain(DockItem):
                                             param_model.auto_fit_all)
                     except (AttributeError, ValueError):
                         pass
+                    if plot_model.plot_exp_opt:
+                        plot_model.plot_exp_opt = False
+                        plot_model.plot_exp_opt = True
                     plot_model.show_fit_opt = True
                 else:
                     plot_model.show_fit_opt = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ matplotlib
 numpy
 pandas
 pillow
-pyqt5<5.11
 requests
 scipy
 six


### PR DESCRIPTION
The update includes:

-- Additional buttons: `Remove` button in `Fit` tab;  `Add line` and `Remove line` buttons in `Spectrum View` tab.

-- Enabling/disabling of peak selection widgets depending on data availability. `Add` and `Remove` buttons are enabled/disabled depending on whether the line highlighted in the ComboBox is in the list of selected lines.

-- Coordination of behavior of line selection tools in `Fit` and `Spectrum View` tabs. Controls from either tab can be used to add and remove lines from the list.

-- Automatic estimation of peak intensity for peak that could be added (simplified estimation as difference between raw and interpolated data). The estimated peak intensity is displayed in the `Peak Int` field of the `Fit` tab. Estimated intensity can be manually changed before the peak is added. For already selected peak, the selected peak intensity is displayed in the `Peak Int` field.

-- Multiple stability issues are fixed.