### PR TITLE
Direct loading data from databroker. ROI settings tab.

### DIFF
--- a/pyxrf/gui.py
+++ b/pyxrf/gui.py
@@ -96,12 +96,15 @@ def run():
 
     # send working directory changes to different models
     io_model.observe('working_directory', fit_model.result_folder_changed)
+    io_model.observe('working_directory', setting_model.result_folder_changed)
     io_model.observe('selected_file_name', fit_model.data_title_update)
     io_model.observe('selected_file_name', plot_model.exp_label_update)
+    io_model.observe('selected_file_name', setting_model.data_title_update)
 
     # send the same file to fit model, as fitting results need to be saved
     io_model.observe('file_name', fit_model.filename_update)
     io_model.observe('file_name', plot_model.plot_exp_data_update)
+    io_model.observe('file_name', setting_model.filename_update)
     io_model.observe('runid', fit_model.runid_update)
 
     # send exp data to different models

--- a/pyxrf/gui.py
+++ b/pyxrf/gui.py
@@ -83,6 +83,9 @@ def run():
     img_model_adv = DrawImageAdvanced()
     img_model_rgb = DrawImageRGB()
 
+    # Initialization needed to eliminate program crash
+    plot_model.roi_dict = setting_model.roi_dict
+
     # Output log to gui, turn off for now
     # error at mac, works fine on linux
     # so log info only outputs to terminal for now.

--- a/pyxrf/gui.py
+++ b/pyxrf/gui.py
@@ -113,6 +113,7 @@ def run():
     io_model.observe('data', fit_model.exp_data_update)
     io_model.observe('data_all', fit_model.exp_data_all_update)
     io_model.observe('img_dict', fit_model.img_dict_update)
+    io_model.observe('img_dict', setting_model.img_dict_update)
 
     # send fitting param of summed spectrum to param_model
     io_model.observe('param_fit', param_model.param_from_db_update)

--- a/pyxrf/model/command_tools.py
+++ b/pyxrf/model/command_tools.py
@@ -358,7 +358,6 @@ def pyxrf_batch(start_id=None, end_id=None, *, param_file_name, data_files=None,
                 else:
                     print(f"WARNING: file {fln} does not exist.")
 
-
     else:
 
         # ``data_files`` parameter is None

--- a/pyxrf/model/command_tools.py
+++ b/pyxrf/model/command_tools.py
@@ -375,10 +375,11 @@ def pyxrf_batch(start_id=None, end_id=None, *, param_file_name, data_files=None,
             flist = [fname for fname in all_files
                      if re.search(f"^[^_]*_{str(start_id)}\D+", os.path.basename(fname))]  # noqa: W605
             if len(flist) < 1:
+                msg = f"File with Scan ID {start_id} was not found"
                 if allow_raising_exceptions:
-                    raise IOError(f"File with Scan ID {start_id} was not found")
+                    raise IOError(msg)
                 else:
-                    print(f"File with Scan ID {start_id} was not found.")
+                    print(msg)
             else:
                 print(f"Processing file with Scan ID {start_id}")
         else:

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -138,7 +138,7 @@ class DrawImageAdvanced(Atom):
 
         if 'positions' in self.data_dict:
             try:
-                logger.info('get pos {}'.format(list(self.data_dict['positions'].keys())))
+                logger.debug(f"Position keys: {list(self.data_dict['positions'].keys())}")
                 self.x_pos = list(self.data_dict['positions']['x_pos'][0, :])
                 self.y_pos = list(self.data_dict['positions']['y_pos'][:, -1])
                 # when we use imshow, the x and y start at lower left,

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -830,7 +830,7 @@ def render_data_to_gui(runid):
     #   Since there is currently no consistent metadata in the start documents
     #   and/or data files, let's leave original labeling conventions for now.
     fname_no_ext = os.path.splitext(os.path.basename(fname))[0]
-    fname_sum = fname_no_ext +'_sum'
+    fname_sum = fname_no_ext + '_sum'
 
     # Determine the number of available detector channels and create the list
     #   of channel names. The channels are named as 'det1', 'det2', 'det3' etc.
@@ -866,7 +866,7 @@ def render_data_to_gui(runid):
             p_dict = {}
             for v in ['x_pos', 'y_pos']:
                 ind = data_out['pos_names'].index(v)
-                p_dict[v] =  data_out['pos_data'][ind, :, :]
+                p_dict[v] = data_out['pos_data'][ind, :, :]
             img_dict['positions'] = p_dict
             logger.info("Data loading: positions data are loaded successfully.")
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -46,7 +46,7 @@ class FileIOModel(Atom):
     file_name : str
         name of loaded file
     file_name_silent_change : bool
-        If this flag is set True, then ``file_name`` may be changed once without
+        If this flag is set to True, then ``file_name`` may be changed once without
         starting file read operation. The flag is automatically reset to False.
     load_status : str
         Description of file loading status

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -798,7 +798,15 @@ def render_data_to_gui(runid):
     data_sets = OrderedDict()
     img_dict = OrderedDict()
 
-    data_from_db = fetch_data_from_db(runid, create_each_det=True, output_to_file=True)
+    data_from_db = fetch_data_from_db(runid,
+                                      # Always create unique file name by adding
+                                      #   version number
+                                      fname_add_version=True,
+                                      # Always load data from all detectors
+                                      create_each_det=True,
+                                      # Always create data file (processing results
+                                      #   are going to be saved in the file)
+                                      output_to_file=True)
 
     ## print(f"data_from_db = {data_from_db}")
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -837,7 +837,7 @@ def render_data_to_gui(runid):
     fname_sum = fname_no_ext +'_sum'
 
     ## print("**** Before any transformation ****")
-    ## print(f"sum of 'det1': {sum(data_out['det1'][2,2,:])}")
+    ## print (f"sum of 'det1': {sum(data_out['det1'][2,2,:])}")
     ## print(f"sum of 'det2': {sum(data_out['det2'][2,2,:])}")
     ## print(f"sum of 'det3': {sum(data_out['det3'][2,2,:])}")
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -721,16 +721,30 @@ def read_hdf_APS(working_directory,
                 except KeyError:
                     print('No data is loaded for {}.'.format(det_name))
 
-                if 'xrf_fit' in data[det_name]:
-                    try:
-                        fit_result = get_fit_data(data[det_name]['xrf_fit_name'].value,
-                                                  data[det_name]['xrf_fit'].value)
-                        img_dict.update({file_channel+'_fit': fit_result})
-                        # also include scaler data
-                        if 'scalers' in data:
-                            img_dict[file_channel+'_fit'].update(img_dict[fname+'_scaler'])
-                    except IndexError:
-                        logger.info('No fitting data is loaded for channel {}.'.format(i))
+        for i in range(1, channel_num + 1):
+            det_name = 'det' + str(i)
+            file_channel = fname + '_det' + str(i)
+            if 'xrf_fit' in data[det_name]:
+                try:
+                    fit_result = get_fit_data(data[det_name]['xrf_fit_name'].value,
+                                              data[det_name]['xrf_fit'].value)
+                    img_dict.update({file_channel+'_fit': fit_result})
+                    # also include scaler data
+                    if 'scalers' in data:
+                        img_dict[file_channel+'_fit'].update(img_dict[fname+'_scaler'])
+                except IndexError:
+                    logger.info('No fitting data is loaded for channel {}.'.format(i))
+
+            if 'xrf_roi' in data[det_name]:
+                try:
+                    fit_result = get_fit_data(data[det_name]['xrf_roi_name'].value,
+                                              data[det_name]['xrf_roi'].value)
+                    img_dict.update({file_channel+'_roi': fit_result})
+                    # also include scaler data
+                    if 'scalers' in data:
+                        img_dict[file_channel+'_roi'].update(img_dict[fname+'_scaler'])
+                except IndexError:
+                    logger.info('No ROI data is loaded for channel {}.'.format(i))
 
         if 'roimap' in data:
             if 'sum_name' in data['roimap']:
@@ -769,6 +783,16 @@ def read_hdf_APS(working_directory,
                     img_dict[fname+'_fit'].update(img_dict[fname+'_scaler'])
             except (IndexError, KeyError):
                 logger.info('No fitting data is loaded for channel summed data.')
+
+        if 'xrf_roi' in data['detsum']:
+            try:
+                fit_result = get_fit_data(data['detsum']['xrf_roi_name'].value,
+                                          data['detsum']['xrf_roi'].value)
+                img_dict.update({fname+'_roi': fit_result})
+                if 'scalers' in data:
+                    img_dict[fname+'_roi'].update(img_dict[fname+'_scaler'])
+            except (IndexError, KeyError):
+                logger.info('No ROI data is loaded for summed data.')
 
     return img_dict, data_sets
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -667,10 +667,10 @@ def read_hdf_APS(working_directory,
             try:
                 # data from channel summed
                 exp_data = np.array(data['detsum/counts'][:, :, 0:spectrum_cut])
-                logger.warning('We use spectrum range from 0 to {}'.format(spectrum_cut))
-                logger.info('Exp. data from h5 has shape of: {}'.format(exp_data.shape))
+                logger.warning(f"We use spectrum range from 0 to {spectrum_cut}")
+                logger.info(f"Exp. data from h5 has shape of: {exp_data.shape}")
 
-                fname_sum = fname+'_sum'
+                fname_sum = f"{fname}_sum"
                 DS = DataSelection(filename=fname_sum,
                                    raw_data=exp_data)
 
@@ -686,10 +686,10 @@ def read_hdf_APS(working_directory,
                 if not isinstance(n, six.string_types):
                     n = n.decode()
                 temp[n] = data['scalers/val'].value[:, :, i]
-            img_dict[fname+'_scaler'] = temp
+            img_dict[f"{fname}_scaler"] = temp
             # also dump other data from suitcase if required
             if len(dict_sc) != 0:
-                img_dict[fname+'_scaler'].update(dict_sc)
+                img_dict[f"{fname}_scaler"].update(dict_sc)
 
         if 'positions' in data:
             pos_name = data['positions/name']
@@ -710,41 +710,41 @@ def read_hdf_APS(working_directory,
         # data from each channel
         if load_each_channel:
             for i in range(1, channel_num+1):
-                det_name = 'det'+str(i)
-                file_channel = fname+'_det'+str(i)
+                det_name = f"det{i}"
+                file_channel = f"{fname}_det{i}"
                 try:
-                    exp_data_new = np.array(data[det_name+'/counts'][:, :, 0:spectrum_cut])
+                    exp_data_new = np.array(data[f"{det_name}/counts"][:, :, 0:spectrum_cut])
                     DS = DataSelection(filename=file_channel,
                                        raw_data=exp_data_new)
                     data_sets[file_channel] = DS
-                    logger.info('Data from detector channel {} is loaded.'.format(i))
+                    logger.info(f"Data from detector channel {i} is loaded.")
                 except KeyError:
-                    print('No data is loaded for {}.'.format(det_name))
+                    print(f"No data is loaded for {det_name}.")
 
         for i in range(1, channel_num + 1):
-            det_name = 'det' + str(i)
-            file_channel = fname + '_det' + str(i)
+            det_name = f"det{i}"
+            file_channel = f"{fname}_det{i}"
             if 'xrf_fit' in data[det_name]:
                 try:
                     fit_result = get_fit_data(data[det_name]['xrf_fit_name'].value,
                                               data[det_name]['xrf_fit'].value)
-                    img_dict.update({file_channel+'_fit': fit_result})
+                    img_dict.update({f"{file_channel}_fit": fit_result})
                     # also include scaler data
                     if 'scalers' in data:
-                        img_dict[file_channel+'_fit'].update(img_dict[fname+'_scaler'])
+                        img_dict[f"{file_channel}_fit"].update(img_dict[f"{fname}_scaler"])
                 except IndexError:
-                    logger.info('No fitting data is loaded for channel {}.'.format(i))
+                    logger.info(f"No fitting data is loaded for channel {i}.")
 
             if 'xrf_roi' in data[det_name]:
                 try:
                     fit_result = get_fit_data(data[det_name]['xrf_roi_name'].value,
                                               data[det_name]['xrf_roi'].value)
-                    img_dict.update({file_channel+'_roi': fit_result})
+                    img_dict.update({f"{file_channel}_roi": fit_result})
                     # also include scaler data
                     if 'scalers' in data:
-                        img_dict[file_channel+'_roi'].update(img_dict[fname+'_scaler'])
+                        img_dict[f"{file_channel}_roi"].update(img_dict[f"{fname}_scaler"])
                 except IndexError:
-                    logger.info('No ROI data is loaded for channel {}.'.format(i))
+                    logger.info(f"No ROI data is loaded for channel {i}.")
 
         if 'roimap' in data:
             if 'sum_name' in data['roimap']:
@@ -757,10 +757,10 @@ def read_hdf_APS(working_directory,
                         temp[n][0, 0] = temp[n][1, 0]
                     except IndexError:
                         temp[n][0, 0] = temp[n][0, 1]
-                img_dict[fname+'_roi'] = temp
+                img_dict[f"{fname}_roi"] = temp
                 # also include scaler data
                 if 'scalers' in data:
-                    img_dict[fname+'_roi'].update(img_dict[fname+'_scaler'])
+                    img_dict[f"{fname}_roi"].update(img_dict[f"{fname}_scaler"])
 
             if 'det_name' in data['roimap']:
                 det_name = data['roimap/det_name']
@@ -771,16 +771,16 @@ def read_hdf_APS(working_directory,
                         temp[n][0, 0] = temp[n][1, 0]
                     except IndexError:
                         temp[n][0, 0] = temp[n][0, 1]
-                img_dict[fname+'_roi_each'] = temp
+                img_dict[f"{fname}_roi_each"] = temp
 
         # read fitting results from summed data
         if 'xrf_fit' in data['detsum']:
             try:
                 fit_result = get_fit_data(data['detsum']['xrf_fit_name'].value,
                                           data['detsum']['xrf_fit'].value)
-                img_dict.update({fname+'_fit': fit_result})
+                img_dict.update({f"{fname}_fit": fit_result})
                 if 'scalers' in data:
-                    img_dict[fname+'_fit'].update(img_dict[fname+'_scaler'])
+                    img_dict[f"{fname}_fit"].update(img_dict[f"{fname}_scaler"])
             except (IndexError, KeyError):
                 logger.info('No fitting data is loaded for channel summed data.')
 
@@ -788,9 +788,9 @@ def read_hdf_APS(working_directory,
             try:
                 fit_result = get_fit_data(data['detsum']['xrf_roi_name'].value,
                                           data['detsum']['xrf_roi'].value)
-                img_dict.update({fname+'_roi': fit_result})
+                img_dict.update({f"{fname}_roi": fit_result})
                 if 'scalers' in data:
-                    img_dict[fname+'_roi'].update(img_dict[fname+'_scaler'])
+                    img_dict[f"{fname}_roi"].update(img_dict[f"{fname}_scaler"])
             except (IndexError, KeyError):
                 logger.info('No ROI data is loaded for summed data.')
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -912,16 +912,20 @@ def render_data_to_gui(runid):
 
     logger.info("Data loading: channel data is loaded successfully.")
 
-    if 'x_pos' in data_out and 'y_pos' in data_out:
-        tmp = {}
-        for v in ['x_pos', 'y_pos']:
-            tmp[v] = data_out[v]
-        img_dict['positions'] = tmp
+    if ('pos_data' in data_out) and ('pos_names' in data_out):
+        if 'x_pos' in data_out['pos_names'] and 'y_pos' in data_out['pos_names']:
+            p_dict = {}
+            for v in ['x_pos', 'y_pos']:
+                ind = data_out['pos_names'].index(v)
+                p_dict[v] =  data_out['pos_data'][ind, :, :]
+            img_dict['positions'] = p_dict
+            logger.info("Data loading: positions data are loaded successfully.")
+
     scaler_tmp = {}
     for i, v in enumerate(data_out['scaler_names']):
         scaler_tmp[v] = data_out['scaler_data'][:, :, i]
     img_dict[fname_no_ext+'_scaler'] = scaler_tmp
-    logger.info("Data loading: position data are loaded successfully.")
+    logger.info("Data loading: scaler data are loaded successfully.")
     return img_dict, data_sets, fname, detector_name
 
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -235,12 +235,6 @@ class FileIOModel(Atom):
 
         self.file_channel_list = list(self.data_sets.keys())
 
-        ## print(f"file_channel_list = {self.file_channel_list}")
-
-        ## print(f"----------- DATA ------------")
-        ## print(f"self.data_sets = {self.data_sets}")
-        ## print(f"img_dict = {img_dict}")
-
         # Disable loading from 'analysis store' for now (because there is no 'analysis store')
         # ----------------------------------------------------------------
         # # Load results from the analysis store
@@ -808,8 +802,6 @@ def render_data_to_gui(runid):
                                       #   are going to be saved in the file)
                                       output_to_file=True)
 
-    ## print(f"data_from_db = {data_from_db}")
-
     if isinstance(data_from_db, str):
         # File name was returned by the function (this happens only for one rare type of scan)
         # Data must be loaded from the file. So again we return a plain string.
@@ -832,10 +824,6 @@ def render_data_to_gui(runid):
     fname = data_from_db[0]['file_name']
     detector_name = data_from_db[0]['detector_name']
 
-    ## print("Data is fetched from the database")
-    ## print(f"data_out = {data_out}")
-    ## print(f"fname = {fname}")
-
     # Create file name for the 'sum' dataset ('file names' are used as dictionary
     #   keys in data storage containers, as channel labels in plot legends,
     #   and as channel names in data selection widgets.
@@ -844,17 +832,9 @@ def render_data_to_gui(runid):
     fname_no_ext = os.path.splitext(os.path.basename(fname))[0]
     fname_sum = fname_no_ext +'_sum'
 
-    ## print("**** Before any transformation ****")
-    ## print (f"sum of 'det1': {sum(data_out['det1'][2,2,:])}")
-    ## print(f"sum of 'det2': {sum(data_out['det2'][2,2,:])}")
-    ## print(f"sum of 'det3': {sum(data_out['det3'][2,2,:])}")
-
-    ## print(f"fname_sum = {fname_sum}")
-
     # Determine the number of available detector channels and create the list
     #   of channel names. The channels are named as 'det1', 'det2', 'det3' etc.
     xrf_det_list = [nm for nm in data_out.keys() if 'det' in nm and 'sum' not in nm]
-    ##print(f"'xrf_det_list' is found: {xrf_det_list}")
 
     det_sum = None
     if 'det_sum' in data_out:
@@ -866,57 +846,18 @@ def render_data_to_gui(runid):
             else:
                 det_sum += data_out[det_name][:, :, 0:spectrum_cut]
 
-    ## print("\n=========================================")
-    ## print("   det_sum")
-    ## ii, kk, mm = det_sum.shape
-    ## sm = np.zeros(shape=(ii, kk))
-    ## for i in range(ii):
-    ##     for k in range(kk):
-    ##         sm[i, k] = sum(det_sum[i,k,:])
-    ## for i in range(ii):
-    ##     print(f"\ni={i} {sm[i,:]}")
-
-    ## print("'det_sum is computed")
     DS = DataSelection(filename=fname_sum,
                        raw_data=det_sum)
     data_sets[fname_sum] = DS
 
     logger.info("Data loading: channel sum is loaded successfully.")
-    ## print("Printing: data of detector sum is loaded")
 
     for det_name in xrf_det_list:
-        ## print(f"\n\n\ndata_out[{det_name}] < {data_out[det_name].shape} > = {data_out[det_name]}")
-        ## print(f"sum = {sum(data_out[det_name][2, 2, :])}")
         exp_data = np.array(data_out[det_name][:, :, 0:spectrum_cut])
         fln = f"{fname_no_ext}_{det_name}"
         DS = DataSelection(filename=fln,
                            raw_data=exp_data)
-        ## if det_name == 'det1':
-        ##     exp_data1_name = det_name
-        ##     exp_data1 = exp_data
         data_sets[fln] = DS
-
-    ## print("\n=========================================")
-    ## print(f"   {exp_data1_name}")
-    ## ii, kk, mm = exp_data1.shape
-    ## sm = np.zeros(shape=(ii, kk))
-    ## for i in range(ii):
-    ##     for k in range(kk):
-    ##         sm[i, k] = sum(exp_data1[i,k,:])
-    ## for i in range(ii):
-    ##     print(f"\ni={i} {sm[i,:]}")
-
-    ## print(f"fname_sum = {fname_sum}")
-    ## print(f"sum of 'det_sum': {sum(data_sets[fname_sum].raw_data[2,2,:])}")
-    ## fln = f"{fname_no_ext}_det1"
-    ## print(f"detector = {fln}")
-    ## print(f"sum of 'det1': {sum(data_sets[fln].raw_data[2,2,:])}")
-    ## fln = f"{fname_no_ext}_det2"
-    ## print(f"detector = {fln}")
-    ## print(f"sum of 'det2': {sum(data_sets[fln].raw_data[2,2,:])}")
-    ## fln = f"{fname_no_ext}_det3"
-    ## print(f"detector = {fln}")
-    ## print(f"sum of 'det3': {sum(data_sets[fln].raw_data[2,2,:])}")
 
     logger.info("Data loading: channel data is loaded successfully.")
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -219,10 +219,8 @@ class FileIOModel(Atom):
 
         rv = render_data_to_gui(self.runid)
 
-        # If string is returned, then treat it as a file name for reading the data.
-        #   This happens for one rare type of scan. All other data is loaded directly.
-        if isinstance(rv, str):
-            self.file_name = os.path.basename(rv)
+        if rv is None:
+            logger.error(f"Data from scan #{self.runid} was not loaded")
             return
 
         img_dict, self.data_sets, fname, detector_name = rv
@@ -801,11 +799,6 @@ def render_data_to_gui(runid):
                                       # Always create data file (processing results
                                       #   are going to be saved in the file)
                                       output_to_file=True)
-
-    if isinstance(data_from_db, str):
-        # File name was returned by the function (this happens only for one rare type of scan)
-        # Data must be loaded from the file. So again we return a plain string.
-        return data_from_db
 
     if not len(data_from_db):
         logger.warning(f"No detector data was found in Scan #{runid}")

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -809,7 +809,7 @@ def render_data_to_gui(runid):
         id number for given run
     """
 
-    spectrum_cut = 3000  # Constant: the number of spectrum points to load 3000 ~ 3 kEv
+    spectrum_cut = 3000  # Constant: the number of spectrum points to load 3000 ~ 3 keV
 
     data_sets = OrderedDict()
     img_dict = OrderedDict()

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -838,7 +838,9 @@ class Fit1D(Atom):
     def create_EC_list(self, element_list):
         temp_dict = OrderedDict()
         for e in element_list:
-            if '-' in e:  # pileup peaks
+            if e == "":
+                pass
+            elif '-' in e:  # pileup peaks
                 e1, e2 = e.split('-')
                 energy = float(get_energy(e1))+float(get_energy(e2))
 

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -692,18 +692,20 @@ class Fit1D(Atom):
         prefix_fname = self.hdf_name.split('.')[0]
         if len(prefix_fname) == 0:
             prefix_fname = 'tmp'
-        if 'det1' in self.data_title:
-            inner_path = 'xrfmap/det1'
-            fit_name = prefix_fname+'_det1_fit'
-        elif 'det2' in self.data_title:
-            inner_path = 'xrfmap/det2'
-            fit_name = prefix_fname+'_det2_fit'
-        elif 'det3' in self.data_title:
-            inner_path = 'xrfmap/det3'
-            fit_name = prefix_fname+'_det3_fit'
-        else:
-            inner_path = 'xrfmap/detsum'
-            fit_name = prefix_fname + '_fit'
+
+        # Generate the path to computed ROIs in the HDF5 file
+        det_name = "detsum"  # Assume that ROIs are computed using the sum of channels
+        fit_name = f"{prefix_fname}_fit"
+
+        # Search for channel name in the data title. Channels are named
+        #   det1, det2, ... , i.e. 'det' followed by integer number.
+        # The channel name is always located at the end of the ``data_title``.
+        # If the channel name is found, then build the path using this name.
+        srch = re.search("det\d+$", self.data_title)
+        if srch:
+            det_name = srch.group(0)
+            fit_name = f"{prefix_fname}_{det_name}_fit"
+        inner_path = f"xrfmap/{det_name}"
 
         # Update GUI so that results can be seen immediately
         self.fit_img[fit_name] = self.result_map

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -5,6 +5,7 @@ import time
 import copy
 import six
 import os
+import re
 import math
 from collections import OrderedDict, deque
 import multiprocessing
@@ -701,7 +702,7 @@ class Fit1D(Atom):
         #   det1, det2, ... , i.e. 'det' followed by integer number.
         # The channel name is always located at the end of the ``data_title``.
         # If the channel name is found, then build the path using this name.
-        srch = re.search("det\d+$", self.data_title)
+        srch = re.search("det\d+$", self.data_title)  # noqa: W605
         if srch:
             det_name = srch.group(0)
             fit_name = f"{prefix_fname}_{det_name}_fit"

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -114,6 +114,10 @@ class ElementController(object):
         threshv : float
             No value is shown when smaller than the threshold value
         """
+        # Do nothing if no elements are selected
+        if not self.element_dict:
+            return
+
         # max_dict = reduce(max, map(np.max, six.itervalues(self.element_dict)))
         max_dict = np.max([v.maxv for v in six.itervalues(self.element_dict)])
 
@@ -226,6 +230,14 @@ class GuessParamModel(Atom):
     file_path : str
         The path where file is saved.
     element_list : list
+        The list of element lines selected for fitting
+    n_selected_elines_for_fitting : Int
+        The number of element lines selected for fitting
+    n_selected_pure_elines_for_fitting : Int
+        The number of element lines selected for fitting
+            excluding pileup peaks and user defined peaks.
+            Only 'pure' lines like Ca_K, K_K etc.
+
     """
     default_parameters = Dict()
     data = Typed(np.ndarray)
@@ -251,6 +263,9 @@ class GuessParamModel(Atom):
 
     energy_bound_high_buf = Float(0.0)
     energy_bound_low_buf = Float(0.0)
+
+    n_selected_elines_for_fitting = Int(0)
+    n_selected_pure_elines_for_fitting = Int(0)
 
     def __init__(self, **kwargs):
         try:
@@ -537,6 +552,14 @@ class GuessParamModel(Atom):
         # need to clean list first, in order to refresh the list in GUI
         self.result_dict_names = []
         self.result_dict_names = list(self.EC.element_dict.keys())
+
+        peak_list = self.get_user_peak_list()
+        # Create the list of selected emission lines such as Ca_K, K_K, etc.
+        #   No pileup or user peaks
+        pure_peak_list = [n for n in self.result_dict_names if n in peak_list]
+        self.n_selected_elines_for_fitting = len(peak_list)
+        self.n_selected_pure_elines_for_fitting = len(pure_peak_list)
+
         # logger.info('The full list for fitting is {}'.format(self.result_dict_names))
 
     def find_peak(self, threshv=0.1):

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -277,9 +277,10 @@ def make_hdf(start, end=None, *, fname=None,
                                    output_to_file=True,
                                    save_scaler=save_scaler,
                                    num_end_lines_excluded=num_end_lines_excluded)
-                print(f"Scan #{v}: File '{filename}' is created.")
-            except Exception:
-                print(f"Scan #{v}: Can not complete the conversion\n")
+                print(f"Scan #{v}: File '{filename}' is created.\n")
+            except Exception as ex:
+                print(f"Scan #{v}: Can not complete the conversion")
+                print(f"    ({ex})\n")
 
 
 def _is_scan_complete(hdr):

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -291,22 +291,21 @@ def _is_scan_complete(hdr):
 
     hdr : databroker.core.Header
         header of the run
-        header = db[scan_id]
+        hdr = db[scan_id]
+        The header must be reloaded each time before the function is called.
 
     Returns
+    -------
 
     True: scan is complete
-    False: scan is incomplete
+    False: scan is incomplete (still running)
     """
 
-    try:
-        # Try to access 'uid' of stop document
-        hdr.stop['uid']
-
-    except Exception:
+    if hdr.stop:
+        return True
+    else:
+        # hdr.stop is an empty dictionary if the scan is incomplete
         return False
-
-    return True
 
 
 def map_data2D_hxn(runid, fpath,

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -400,8 +400,8 @@ def map_data2D_hxn(runid, fpath,
         # output to file
         print('Saving data to hdf file.')
         fpath = write_db_to_hdf_base(fpath, data_out,
-                                         fname_add_version=fname_add_version,
-                                         create_each_det=create_each_det)
+                                     fname_add_version=fname_add_version,
+                                     create_each_det=create_each_det)
 
     detector_name = "xpress3"
     d_dict = {"dataset": data_out, "file_name": fpath, "detector_name": detector_name}
@@ -1276,12 +1276,13 @@ def write_db_to_hdf(fpath, data, datashape,
     return fpath
 
 
-def assemble_data_SRX_stepscan(data, datashape,
-                    det_list=('xspress3_ch1', 'xspress3_ch2', 'xspress3_ch3'),
-                    pos_list=('zpssx[um]', 'zpssy[um]'),
-                    scaler_list=('sclr1_ch3', 'sclr1_ch4'),
-                    fname_add_version=False,
-                    fly_type=None, subscan_dims=None, base_val=None):
+def assemble_data_SRX_stepscan(
+        data, datashape,
+        det_list=('xspress3_ch1', 'xspress3_ch2', 'xspress3_ch3'),
+        pos_list=('zpssx[um]', 'zpssy[um]'),
+        scaler_list=('sclr1_ch3', 'sclr1_ch4'),
+        fname_add_version=False,
+        fly_type=None, subscan_dims=None, base_val=None):
     """
     Convert stepscan data from SRX beamline obtained from databroker into the for accepted
     by ``write_db_to_hdf_base`` function.
@@ -1341,7 +1342,6 @@ def assemble_data_SRX_stepscan(data, datashape,
 
             data_assembled[detname] = new_data
 
-
     if sum_data is not None:
         data_assembled['det_sum'] = sum_data
 
@@ -1393,7 +1393,6 @@ def assemble_data_SRX_stepscan(data, datashape,
     data_assembled['scaler_data'] = scaler_data[:new_v_shape, :]
 
     return data_assembled
-
 
 
 def get_name_value_from_db(name_list, data, datashape):

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -223,7 +223,7 @@ def make_hdf(start, end=None, *, fname=None,
                         # Load scan if it is available
                         make_hdf(scan_id, completed_scans_only=True)
                         # Process the file using the prepared parameter file
-                        pyxrf_batch(scan_id, param_file_name = "some_parameter_file.json")
+                        pyxrf_batch(scan_id, param_file_name="some_parameter_file.json")
                         break
                     except Exception:
                         # Wait for 10 minutes and retry

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -224,6 +224,10 @@ def map_data2D_hxn(runid, fpath,
     """
     hdr = db[runid]
 
+    # Generate the default file name for the scan
+    if fpath is None:
+        fpath = f"scan2D_{runid}.h5"
+
     # Output data is the list of data structures for all available detectors
     data_output = []
 
@@ -752,6 +756,10 @@ def map_data2D_tes(runid, fpath,
     hdr = db[runid]
     # start_doc = hdr['start']
 
+    # Generate the default file name for the scan
+    if fpath is None:
+        fpath = f"scan2D_{runid}.h5"
+
     # Load configuration file
     current_dir = os.path.dirname(os.path.realpath(__file__))
     config_file = 'tes_pv_config.json'
@@ -869,7 +877,7 @@ def map_data2D_tes(runid, fpath,
     d_dict = {"dataset": new_data, "file_name": fpath_out, "detector_name": detector_name}
     data_output.append(d_dict)
 
-    return new_data
+    return data_output
 
 
 def map_data2D_xfm(runid, fpath,

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -188,13 +188,25 @@ def make_hdf(start, end=None, *, fname=None,
         error occurs during the conversion. If ``end`` is specified, then scans in the
         range ``scan``..``end`` are converted and a scan in the sequence is skipped
         if there is an issue during the conversion. For example:
+
+        .. code-block:: python
+
             make_hdf(2342)
+
         will process scan #2342 and throw an exception if error occurs. On the other hand
+
+        .. code-block:: python
+
             make_hdf(2342, 2342)
+
         will process scan #2342 and write data to file if conversion is successful, otherwise
         no file will be created. The scans with IDs in the range 2342..2441 can be processed by
         calling
+
+        .. code-block:: python
+
             make_hdf(2342, 2441)
+
         Non-existing scans in the range or scans causing errors during conversion will be skipped.
 
     Keyword parameters
@@ -217,6 +229,9 @@ def make_hdf(start, end=None, *, fname=None,
         encountered: an exception is thrown (``end`` is not specified) or the scan
         is skipped (``end`` is specified). This feature allows to use
         ``make_hdf`` as part of the script for real time data analysis:
+
+        .. code-block:: python
+
             for scan_id in range(n_start, n_start + n_scans):
                 while True:
                     try:
@@ -228,6 +243,7 @@ def make_hdf(start, end=None, *, fname=None,
                     except Exception:
                         # Wait for 10 minutes and retry
                         time.sleep(600)
+
         Such scripts are currently used at HXN and SRX beamlines of NSLS-II, so this feature
         supports the existing workflows.
         False: the feature is disabled, incomplete scan will be processed.
@@ -301,11 +317,8 @@ def _is_scan_complete(hdr):
     False: scan is incomplete (still running)
     """
 
-    if hdr.stop:
-        return True
-    else:
-        # hdr.stop is an empty dictionary if the scan is incomplete
-        return False
+    # hdr.stop is an empty dictionary if the scan is incomplete
+    return bool(hdr.stop)
 
 
 def map_data2D_hxn(runid, fpath,

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -233,7 +233,7 @@ def make_hdf(start, end=None, *, fname=None,
         False: the feature is disabled, incomplete scan will be processed.
     prefix : str, optional
         prefix name of the created data file. If ``fname`` is not specified, it is generated
-        automatically in the form ``<prefix>_<scanID>_<some_additional data>.h5``
+        automatically in the form ``<prefix>_<scanID>_<some_additional_data>.h5``
     create_each_det: bool, optional
         True: save data for each available detector channel into a file. Enabling this
         feature leads to larger data files. Inspection of data from individual channels

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -89,7 +89,7 @@ def fetch_data_from_db(runid, fpath=None,
                        fname_add_version=False,
                        completed_scans_only=False,
                        output_to_file=False,
-                       save_scalar=True,
+                       save_scaler=True,
                        num_end_lines_excluded=None):
     """
     Read data from databroker.
@@ -122,7 +122,7 @@ def fetch_data_from_db(runid, fpath=None,
         False: the feature is disabled, incomplete scan will be processed.
     output_to_file : bool, optional
         save data to hdf5 file if True
-    save_scalar : bool, optional
+    save_scaler : bool, optional
         choose to save scaler data or not for srx beamline, test purpose only.
     num_end_lines_excluded : int, optional
         remove the last few bad lines
@@ -147,7 +147,7 @@ def fetch_data_from_db(runid, fpath=None,
                               fname_add_version=fname_add_version,
                               completed_scans_only=completed_scans_only,
                               output_to_file=output_to_file,
-                              save_scalar=save_scalar,
+                              save_scaler=save_scaler,
                               num_end_lines_excluded=num_end_lines_excluded)
     elif hdr.start.beamline_id == 'XFM':
         data = map_data2D_xfm(runid, fpath,
@@ -260,7 +260,7 @@ def make_hdf(start, end=None, *, fname=None,
                            fname_add_version=fname_add_version,
                            completed_scans_only=completed_scans_only,
                            output_to_file=True,
-                           save_scalar=save_scalar,
+                           save_scaler=save_scaler,
                            num_end_lines_excluded=num_end_lines_excluded)
     else:
         # Both ``start`` and ``end`` are specified. Convert the scans in the range
@@ -275,7 +275,7 @@ def make_hdf(start, end=None, *, fname=None,
                                    fname_add_version=fname_add_version,
                                    completed_scans_only=completed_scans_only,
                                    output_to_file=True,
-                                   save_scalar=save_scalar,
+                                   save_scaler=save_scaler,
                                    num_end_lines_excluded=num_end_lines_excluded)
                 print(f"Scan #{v}: File '{filename}' is created.")
             except Exception:
@@ -445,7 +445,7 @@ def map_data2D_srx(runid, fpath,
                    fname_add_version=False,
                    completed_scans_only=False,
                    output_to_file=True,
-                   save_scalar=True,
+                   save_scaler=True,
                    num_end_lines_excluded=None):
     """
     Transfer the data from databroker into a correct format following the
@@ -478,7 +478,7 @@ def map_data2D_srx(runid, fpath,
         False: the feature is disabled, incomplete scan will be processed.
     output_to_file : bool, optional
         save data to hdf5 file if True
-    save_scalar : bool, optional
+    save_scaler : bool, optional
         choose to save scaler data or not for srx beamline, test purpose only.
     num_end_lines_excluded : int, optional
         remove the last few bad lines
@@ -593,7 +593,7 @@ def map_data2D_srx(runid, fpath,
         print(f"         Loading SRX fly scan           ")
         print(f"****************************************")
 
-        if save_scalar is True:
+        if save_scaler is True:
             scaler_list = ['i0', 'time', 'i0_time', 'time_diff']
             xpos_name = 'enc1'
             ypos_name = 'hf_stage_y'  # 'hf_stage_x' if fast axis is vertical
@@ -650,10 +650,10 @@ def map_data2D_srx(runid, fpath,
             new_data = {}
             data = {}
 
-            if save_scalar is True:
+            if save_scaler is True:
                 new_data['scaler_names'] = scaler_list
                 scaler_tmp = np.zeros([datashape[0], datashape[1], len(scaler_list)])
-                if vertical_fast is True:  # data shape only has impact on scalar data
+                if vertical_fast is True:  # data shape only has impact on scaler data
                     scaler_tmp = np.zeros([datashape[1], datashape[0], len(scaler_list)])
                 for v in scaler_list+[xpos_name]:
                     data[v] = np.zeros([datashape[0], datashape[1]])
@@ -688,7 +688,7 @@ def map_data2D_srx(runid, fpath,
                     print(f"Number of the detector channels: {num_det}")
 
                 if m < datashape[0]:   # scan is not finished
-                    if save_scalar is True:
+                    if save_scaler is True:
                         for n in scaler_list[:-1] + [xpos_name]:
                             min_len = min(v.data[n].size, datashape[1])
                             data[n][m, :min_len] = v.data[n][:min_len]
@@ -732,7 +732,7 @@ def map_data2D_srx(runid, fpath,
                     for i in range(num_det):
                         new_data['det'+str(i+1)] = np.transpose(new_data['det'+str(i+1)], axes=(1, 0, 2))
 
-            if save_scalar is True:
+            if save_scaler is True:
                 if vertical_fast is False:
                     for i, v in enumerate(scaler_list[:-1]):
                         scaler_tmp[:, :, i] = data[v]
@@ -830,7 +830,7 @@ def map_data2D_srx(runid, fpath,
                     new_data['pos_data'] = data_tmp
                     new_data['pos_names'] = ['x_pos', 'y_pos']
                     if vertical_fast is True:  # need to transpose the data, as we scan y first
-                        # fast scan on y has impact for scalar data
+                        # fast scan on y has impact for scaler data
                         data_tmp = np.zeros([2, x_pos.shape[1], x_pos.shape[0]])
                         data_tmp[1, :, :] = x_pos.T
                         data_tmp[0, :, :] = yv.T

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -187,7 +187,7 @@ def make_hdf(start, end=None, *, fname=None,
         only the scan with ID ``start`` is converted and an exception is raised if an
         error occurs during the conversion. If ``end`` is specified, then scans in the
         range ``scan``..``end`` are converted and a scan in the sequence is skipped
-        if there is an issues during the conversion. For example:
+        if there is an issue during the conversion. For example:
             make_hdf(2342)
         will process scan #2342 and throw an exception if error occurs. On the other hand
             make_hdf(2342, 2342)

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -221,7 +221,7 @@ def make_hdf(start, end=None, *, fname=None,
                 while True:
                     try:
                         # Load scan if it is available
-                        make_hdf(scan_id, completed_scans_only = True)
+                        make_hdf(scan_id, completed_scans_only=True)
                         # Process the file using the prepared parameter file
                         pyxrf_batch(scan_id, param_file_name = "some_parameter_file.json")
                         break

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1210,7 +1210,7 @@ def write_db_to_hdf(fpath, data, datashape,
                     new_data = flip_data(new_data, subscan_dims=subscan_dims)
 
                 if sum_data is None:
-                    sum_data = new_data
+                    sum_data = np.copy(new_data)
                 else:
                     sum_data += new_data
                 ds_data = dataGrp.create_dataset('counts', data=new_data, compression='gzip')

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -277,7 +277,7 @@ def make_hdf(start, end=None, *, fname=None,
                                    output_to_file=True,
                                    save_scaler=save_scaler,
                                    num_end_lines_excluded=num_end_lines_excluded)
-                print(f"Scan #{v}: File '{filename}' is created.\n")
+                print(f"Scan #{v}: Conversion completed.\n")
             except Exception as ex:
                 print(f"Scan #{v}: Can not complete the conversion")
                 print(f"    ({ex})\n")

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -181,7 +181,7 @@ def make_hdf(start, end=None, *, fname=None,
     ---------
 
     start : int
-        scan ID of the fist scan to convert.
+        scan ID of the first scan to convert.
     end : int, optional
         scan ID of the last scan to convert. If ``end`` is not specified or None, then
         only the scan with ID ``start`` is converted and an exception is raised if an

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -849,7 +849,7 @@ def map_data2D_tes(runid, fpath,
             print("The number of lines is less than expected")
             break
         data = v.data[detector_field]
-        data_det1 = data[:, 0, :]
+        data_det1 = np.array(data[:, 0, :])
         detector_data[n, :, :] = data_det1
         n_events_found = n + 1
     if n_events_found < n_events:
@@ -1157,8 +1157,9 @@ def map_data2D(data, datashape,
                 new_data = flip_data(new_data, subscan_dims=subscan_dims)
             data_output[detname] = new_data
             if sum_data is None:
-                sum_data = new_data
+                sum_data = np.copy(new_data)
             else:
+                sum_data += new_data
                 sum_data += new_data
     data_output['det_sum'] = sum_data
 

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -227,7 +227,7 @@ def make_hdf(start, end=None, *, fname=None,
                         break
                     except Exception:
                         # Wait for 10 minutes and retry
-                        pause(600)
+                        time.sleep(600)
         Such scripts are currently used at HXN and SRX beamlines of NSLS-II, so this feature
         supports the existing workflows.
         False: the feature is disabled, incomplete scan will be processed.

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -178,7 +178,7 @@ def make_hdf(start, end=None, *, fname=None,
     Load data from database and save it in HDF5 files.
 
     Parameters
-    ---------
+    ----------
 
     start : int
         scan ID of the first scan to convert.
@@ -209,20 +209,17 @@ def make_hdf(start, end=None, *, fname=None,
 
         Non-existing scans in the range or scans causing errors during conversion will be skipped.
 
-    Keyword parameters
-    ------------------
-
-    fname : string, optional
+    fname : string, optional keyword parameter
         path to save data file when ``end`` is ``None`` (only one scan is processed).
         File name is created automatically if ``fname`` is not specified.
-    fname_add_version : bool
+    fname_add_version : bool, keyword parameter
         True: if file already exists, then file version is added to the file name
         so that it becomes unique in the current directory. The version is
         added to <fname>.h5 in the form <fname>_(1).h5, <fname>_(2).h5, etc.
         False: then conversion fails. If ``end`` is ``None``, then
         the exception is raised. If ``end`` is specified, the scan is skipped
         and the next scan in the range is processed.
-    completed_scans_only : bool
+    completed_scans_only : bool, keyword parameter
         True: process only completed scans (for which ``stop`` document exists in
         the database). Failed scan for which ``stop`` document exists are considered
         completed even if not the whole image was scanned. If incomplete scan is
@@ -232,6 +229,9 @@ def make_hdf(start, end=None, *, fname=None,
 
         .. code-block:: python
 
+            # Wait time between retires in seconds. Select the value appropriate
+            #   for the workflow type.
+            wait_time = 600  # Wait for 10 minuts between retries.
             for scan_id in range(n_start, n_start + n_scans):
                 while True:
                     try:
@@ -241,8 +241,7 @@ def make_hdf(start, end=None, *, fname=None,
                         pyxrf_batch(scan_id, param_file_name="some_parameter_file.json")
                         break
                     except Exception:
-                        # Wait for 10 minutes and retry
-                        time.sleep(600)
+                        time.sleep(wait_time)
 
         Such scripts are currently used at HXN and SRX beamlines of NSLS-II, so this feature
         supports the existing workflows.

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -169,8 +169,8 @@ def fetch_data_from_db(runid, fpath=None,
 
 
 def make_hdf(start, end=None, *, fname=None,
-             fname_add_version = False,
-             completed_scans_only = False,
+             fname_add_version=False,
+             completed_scans_only=False,
              prefix='scan2D_',
              create_each_det=True, save_scaler=True,
              num_end_lines_excluded=None):
@@ -279,7 +279,7 @@ def make_hdf(start, end=None, *, fname=None,
                                    num_end_lines_excluded=num_end_lines_excluded)
                 print(f"Scan #{v}: File '{filename}' is created.")
             except Exception:
-                print(f"Scan #{v}: Can not complete the conversion")
+                print(f"Scan #{v}: Can not complete the conversion\n")
 
 
 def _is_scan_complete(hdr):
@@ -306,6 +306,7 @@ def _is_scan_complete(hdr):
         return False
 
     return True
+
 
 def map_data2D_hxn(runid, fpath,
                    create_each_det=False,
@@ -553,7 +554,8 @@ def map_data2D_srx(runid, fpath,
                 print('Saving data to hdf file: Xpress3 detector #1 (three channels).')
                 root, ext = os.path.splitext(fpath)
                 fpath_out = f"{root + '_xs'}{ext}"
-                fpath_out = write_db_to_hdf(fpath_out, data,
+                fpath_out = write_db_to_hdf(
+                    fpath_out, data,
                     # hdr.start.datashape,
                     datashape,
                     det_list=config_data['xrf_detector'],
@@ -567,7 +569,8 @@ def map_data2D_srx(runid, fpath,
                 print('Saving data to hdf file: Xpress3 detector #2 (single channel).')
                 root, ext = os.path.splitext(fpath)
                 fpath_out = f"{root}_xs2{ext}"
-                fpath_out = write_db_to_hdf(fpath_out, data,
+                fpath_out = write_db_to_hdf(
+                    fpath_out, data,
                     datashape,
                     det_list=config_data['xrf_detector2'],
                     pos_list=hdr.start.motors,
@@ -1269,6 +1272,7 @@ def write_db_to_hdf(fpath, data, datashape,
 
     return fpath
 
+
 def get_name_value_from_db(name_list, data, datashape):
     """
     Get name and data from db.
@@ -1395,6 +1399,7 @@ def map_data2D(data, datashape,
     data_output['scaler_data'] = scaler_data
     return data_output
 
+
 def _get_fpath_not_existing(fpath):
     # Returns path to the new file that is guaranteed to not exist
     # The function cycles through paths obtained by inserting
@@ -1484,6 +1489,7 @@ def write_db_to_hdf_base(fpath, data,
             dataGrp.create_dataset('val', data=scaler_data)
 
     return fpath
+
 
 def free_memory_from_handler():
     """Quick way to set 3D dataset at handler to None to release memory.

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1544,7 +1544,7 @@ def write_db_to_hdf_base(fpath, data,
                          create_each_det=True):
     """
     This is the function used to save raw experiment data into HDF5 file.
-    Typicall used after data is loaded from databroker.
+    Typically used after data is loaded from databroker.
 
     Parameters
     ----------

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -118,7 +118,7 @@ def fetch_data_from_db(runid, fpath=None,
         True: process only completed scans (for which ``stop`` document exists in
         the database). Failed scan for which ``stop`` document exists are considered
         completed even if not the whole image was scanned. If incomplete scan is
-        encountered: an exception is thrown.
+        encountered, an exception is thrown.
         False: the feature is disabled, incomplete scan will be processed.
     output_to_file : bool, optional
         save data to hdf5 file if True

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -286,7 +286,6 @@ class SettingModel(Atom):
             else:
                 data_roi = data_raw
 
-
             for k, v in six.iteritems(self.roi_dict):
                 leftv = v.left_val/1000
                 rightv = v.right_val/1000

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -311,10 +311,6 @@ class SettingModel(Atom):
         """
         roi_result = {}
 
-        #for fname, datav in six.iteritems(self.data_sets):
-        #    # quick way to ignore channel data, only for summed data
-        #    # to be updated
-
         datav = self.data_sets[self.data_title]
 
         logger.info(f"Computing ROIs for dataset {self.data_title} ...")

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -348,7 +348,7 @@ class SettingModel(Atom):
             logger.info(f"Subtracting background ...")
 
             num_processors_to_use = multiprocessing.cpu_count()
-            logger.info(f"Cpu count: {format(num_processors_to_use)}")
+            logger.info(f"Cpu count: {num_processors_to_use}")
             pool = multiprocessing.Pool(num_processors_to_use)
 
             result_pool = [pool.apply_async(

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -313,7 +313,7 @@ class SettingModel(Atom):
             self.roi_dict.update({v: roi})
 
         # remove old items not included in element_list
-        for k in six.iterkeys(self.roi_dict.copy()):
+        for k in self.roi_dict.copy().keys():
             if k not in element_list:
                 del self.roi_dict[k]
 
@@ -374,7 +374,7 @@ class SettingModel(Atom):
         else:
             data_roi = data_raw
 
-        for k, v in six.iteritems(self.roi_dict):
+        for k, v in self.roi_dict.keys():
             leftv = v.left_val/1000
             rightv = v.right_val/1000
             sum2D = calculate_roi(data_roi,
@@ -401,14 +401,17 @@ class SettingModel(Atom):
 
     def saveROImap_to_hdf(self, data_dict_roi):
 
-        if 'det1' in self.data_title:
-            inner_path = 'xrfmap/det1'
-        elif 'det2' in self.data_title:
-            inner_path = 'xrfmap/det2'
-        elif 'det3' in self.data_title:
-            inner_path = 'xrfmap/det3'
-        else:
-            inner_path = 'xrfmap/detsum'
+        # Generate the path to computed ROIs in the HDF5 file
+        det_name = "detsum"  # Assume that ROIs are computed using the sum of channels
+
+        # Search for channel name in the data title. Channels are named
+        #   det1, det2, ... , i.e. 'det' followed by integer number.
+        # The channel name is always located at the end of the ``data_title``.
+        # If the channel name is found, then build the path using this name.
+        srch = re.search("det\d+$", self.data_title)
+        if srch:
+            det_name = srch.group(0)
+        inner_path = f"xrfmap/{det_name}"
 
         try:
             save_fitdata_to_hdf(self.hdf_path, data_dict_roi, datapath=inner_path,

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -1,11 +1,11 @@
 from __future__ import (absolute_import, division,
                         print_function)
 
-import six
 import numpy as np
 from collections import OrderedDict
 import copy
 import os
+import re
 
 from atom.api import (Atom, Str, observe, Dict, List, Int, Bool)
 
@@ -408,7 +408,7 @@ class SettingModel(Atom):
         #   det1, det2, ... , i.e. 'det' followed by integer number.
         # The channel name is always located at the end of the ``data_title``.
         # If the channel name is found, then build the path using this name.
-        srch = re.search("det\d+$", self.data_title)
+        srch = re.search("det\d+$", self.data_title)  # noqa: W605
         if srch:
             det_name = srch.group(0)
         inner_path = f"xrfmap/{det_name}"

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -5,6 +5,7 @@ import six
 import numpy as np
 from collections import OrderedDict
 import copy
+import os
 
 from atom.api import (Atom, Str, observe, Dict, List, Int, Bool)
 
@@ -83,6 +84,13 @@ class SettingModel(Atom):
         enables/disables GUI element that start ROI computation
         At least one element must be selected and all entry in the element
           list must be valid before ROI may be computed
+
+    result_folder : Str
+        directory which contains HDF5 file, in which results of processing are saved
+    hdf_path : Str
+        full path to the HDF5 file, in which results are saved
+    hdf_name : Str
+        name of the HDF file, in which results are saved
     """
     parameters = Dict()
     data_sets = Dict()
@@ -94,6 +102,54 @@ class SettingModel(Atom):
     enable_roi_computation = Bool(False)
 
     subtract_background = Bool(False)
+
+    result_folder = Str()
+
+    hdf_path = Str()
+    hdf_name = Str()
+
+    data_title = Str()
+
+    def filename_update(self, change):
+        """
+        Observer function to be connected to the fileio model
+        in the top-level gui.py startup
+
+        Parameters
+        ----------
+        changed : dict
+            This is the dictionary that gets passed to a function
+            with the @observe decorator
+        """
+        self.hdf_name = change['value']
+        # output to .h5 file
+        self.hdf_path = os.path.join(self.result_folder, self.hdf_name)
+
+    def result_folder_changed(self, change):
+        """
+        Observer function to be connected to the fileio model
+        in the top-level gui.py startup
+
+        Parameters
+        ----------
+        changed : dict
+            This is the dictionary that gets passed to a function
+            with the @observe decorator
+        """
+        self.result_folder = change['value']
+
+    def data_title_update(self, change):
+        """
+        Observer function to be connected to the fileio model
+        in the top-level gui.py startup
+
+        Parameters
+        ----------
+        changed : dict
+            This is the dictionary that gets passed to a function
+            with the @observe decorator
+        """
+        self.data_title = change['value']
 
     def __init__(self, *args, **kwargs):
         self.parameters = kwargs['default_parameters']

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -374,7 +374,7 @@ class SettingModel(Atom):
         else:
             data_roi = data_raw
 
-        for k, v in self.roi_dict.keys():
+        for k, v in self.roi_dict.items():
             leftv = v.left_val/1000
             rightv = v.right_val/1000
             sum2D = calculate_roi(data_roi,

--- a/pyxrf/view/fileio.enaml
+++ b/pyxrf/view/fileio.enaml
@@ -162,16 +162,13 @@ enamldef FileView(DockItem): file_view:
                             folder_btn.enabled = False
 
                             # do not import original data for 2D image
-                            #img_model_adv.data_dict = io_model.img_dict
-
-                            # data passed for auto fitting and final fit
-                            #param_model.data_sets = io_model.data_sets
+                            # img_model_adv.data_dict = io_model.img_dict
 
                             plot_model.parameters = param_model.param_new
-
-                            #setting_model.parameters = param_model.param_new
-                            #setting_model.data_sets = io_model.data_sets
-                            #fit_model.save_name = io_model.file_names[0]
+                            setting_model.parameters = param_model.param_new
+                            setting_model.data_sets = io_model.data_sets
+                            fit_model.data_sets = io_model.data_sets
+                            fit_model.fit_img = {} # clear dict in fitmodel to rm old results
 
                             # Change window title (include run id)
                             io_model.window_title_set_run_id(io_model.runid)

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -177,7 +177,7 @@ enamldef FitView(DockItem): fit_view:
             padding = Box(2, 2, 2, 2)
             constraints = [
                 vbox(
-                    hbox(btn_cb_prev, cb_select, btn_cb_next, intensity_lb, intensity_fd,
+                    hbox(btn_cb_prev, btn_cb_next, cb_select, intensity_lb, intensity_fd,
                          manual_add, manual_remove, spacer, pb_pileup),
                     pre_fit,
                     #hbox(saveas_btn, spacer),
@@ -195,18 +195,23 @@ enamldef FitView(DockItem): fit_view:
                         param_model.e_name = cb_select.selected_item
 
             PushButton: btn_cb_prev:
-                text = '<<'
+                text = '<'
                 enabled << plot_model.allow_select_elines
+                maximum_size = (15, 24)
                 clicked ::
                     if cb_select.index > 1:
                         cb_select.index -= 1
+                    cb_select.set_focus()  # Return focus to the combo box
+
 
             PushButton: btn_cb_next:
-                text = '>>'
+                text = '>'
                 enabled << plot_model.allow_select_elines
+                maximum_size = (15, 24)
                 clicked ::
                     if cb_select.index < len(cb_select.items) - 1:
                         cb_select.index += 1
+                    cb_select.set_focus()  # Return focus to the combo box
 
             Label: intensity_lb:
                 text = 'Peak Int'

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -177,7 +177,7 @@ enamldef FitView(DockItem): fit_view:
             padding = Box(2, 2, 2, 2)
             constraints = [
                 vbox(
-                    hbox(cb_select, intensity_lb, intensity_fd,
+                    hbox(btn_cb_prev, cb_select, btn_cb_next, intensity_lb, intensity_fd,
                          manual_add, manual_remove, spacer, pb_pileup),
                     pre_fit,
                     #hbox(saveas_btn, spacer),
@@ -193,6 +193,20 @@ enamldef FitView(DockItem): fit_view:
                 index ::
                     if cb_select.index > 0:
                         param_model.e_name = cb_select.selected_item
+
+            PushButton: btn_cb_prev:
+                text = '<<'
+                enabled << plot_model.allow_select_elines
+                clicked ::
+                    if cb_select.index > 1:
+                        cb_select.index -= 1
+
+            PushButton: btn_cb_next:
+                text = '>>'
+                enabled << plot_model.allow_select_elines
+                clicked ::
+                    if cb_select.index < len(cb_select.items) - 1:
+                        cb_select.index += 1
 
             Label: intensity_lb:
                 text = 'Peak Int'

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -753,7 +753,8 @@ enamldef FitView(DockItem): fit_view:
 
             PushButton: to_db:
                 text = 'Save to database'
-                enabled = databroker is not None
+                enabled = False  # Disable this button (database for processing data does not exist yet)
+                #enabled = databroker is not None
                 #minimum_size = (20, 20)
                 clicked ::
                     fit_model.save_pixel_fitting_to_db()

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -47,7 +47,7 @@ enamldef PlotMain(DockItem):
         constraints = [
             vbox(
                 hbox(plot_exp_btn, pb_plot_fit, spacer, pb_print),
-                hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, cbox2, checkb),
+                hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, cbox2, btn_cb_prev, btn_cb_next, checkb),
                 canvas,
             ),
         ]
@@ -91,6 +91,24 @@ enamldef PlotMain(DockItem):
             index ::
                 if cbox2.index > 0:
                     param_model.e_name = cbox2.selected_item
+
+        PushButton: btn_cb_prev:
+            text = '<'
+            enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt
+            maximum_size = (15, 24)
+            clicked ::
+                if cbox2.index > 1:
+                    cbox2.index -= 1
+                cbox2.set_focus()  # Return focus to the combo box
+
+        PushButton: btn_cb_next:
+            text = '>'
+            enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt
+            maximum_size = (15, 24)
+            clicked ::
+                if cbox2.index < len(cbox2.items) - 1:
+                    cbox2.index += 1
+                cbox2.set_focus()  # Return focus to the combo box
 
         PushButton: pb_print:
             text  ='Print'

--- a/pyxrf/view/main_window.enaml
+++ b/pyxrf/view/main_window.enaml
@@ -121,6 +121,7 @@ enamldef XRFGui(MainWindow): main_window:
                 title = 'ROI Setting'
                 io_model = main_window.io_model
                 plot_model = main_window.plot_model
+                param_model = main_window.param_model
                 img_model_adv = main_window.img_model_adv
                 img_model_rgb = main_window.img_model_rgb
                 setting_model = main_window.setting_model

--- a/pyxrf/view/setting.enaml
+++ b/pyxrf/view/setting.enaml
@@ -85,7 +85,11 @@ enamldef SettingView(DockItem):
 
                         #img_model_adv.set_initial_stat()
 
-                        time.sleep(1)  # 1 s. delay for ergonomic purposes (computations are instant)
+                        if not setting_model.subtract_background:
+                            # If background is not subtracted, then computations
+                            #   are almost instant. Additional short delay of 0.5s
+                            #   before message box pops up makes GUI feel more natural.
+                            time.sleep(0.5)
                         information(self, "Job Completed",
                                     "ROI are successfully computed. Use 'Element Map' "
                                     "and 'Element RGB' tabs to view the results")

--- a/pyxrf/view/setting.enaml
+++ b/pyxrf/view/setting.enaml
@@ -53,7 +53,7 @@ enamldef SettingView(DockItem):
             Field: element_fd:
                 text := setting_model.element_for_roi
             Label: prefix_lbl:
-                text = 'Prefix'
+                text = 'Label'
             Field: prefix_fd:
                 text := setting_model.prefix_name_roi
                 submit_triggers = ['auto_sync']
@@ -67,7 +67,7 @@ enamldef SettingView(DockItem):
                     if len(setting_model.element_for_roi) == 0:
                         warning(self, 'Warning Dialog', 'Please select at least one element.')
                     elif len(setting_model.prefix_name_roi) == 0:
-                        warning(self, 'Warning Dialog', 'Please enter prefix name.')
+                        warning(self, 'Warning Dialog', 'Please enter Label name.')
                     else:
                         #box = MessageBox()
                         #box.title = 'Warning Message'

--- a/pyxrf/view/setting.enaml
+++ b/pyxrf/view/setting.enaml
@@ -15,6 +15,7 @@ import numpy as np
 enamldef SettingView(DockItem):
     attr io_model
     attr plot_model
+    attr param_model
     attr img_model_adv
     attr img_model_rgb
     attr setting_model
@@ -23,7 +24,7 @@ enamldef SettingView(DockItem):
         Container:
             constraints = [
                 vbox(
-                    hbox(setup_lbl, spacer, use_default),
+                    hbox(setup_lbl, spacer, clear_element_list, use_selected),
                     hbox(element_fd),
                     scroller,
                     hbox(prefix_lbl, prefix_fd, spacer, calculate_btn),
@@ -32,10 +33,15 @@ enamldef SettingView(DockItem):
             ]
             Label: setup_lbl:
                 text = 'ROI Setup: enter elements below, e.g., Fe_K, Gd_L'
-            PushButton: use_default:
-                text = 'Use default elements'
+            PushButton: clear_element_list:
+                text = 'Clear'
                 clicked ::
-                    setting_model.use_default_elements()
+                    setting_model.clear_selected_elements()
+            PushButton: use_selected:
+                text = 'Use lines selected for fitting'
+                clicked ::
+                    selected_element_list = param_model.EC.get_element_list()
+                    setting_model.select_elements_from_list(selected_element_list)
             Field: element_fd:
                 text := setting_model.element_for_roi
             Label: prefix_lbl:
@@ -45,6 +51,7 @@ enamldef SettingView(DockItem):
                 submit_triggers = ['auto_sync']
             PushButton: calculate_btn:
                 text = 'Calculate ROI'
+                enabled << setting_model.enable_roi_computation
                 clicked ::
                     if len(setting_model.element_for_roi) == 0:
                         warning(self, 'Warning Dialog', 'Please enter element first.')
@@ -61,9 +68,9 @@ enamldef SettingView(DockItem):
 
                         # visualization purposes
                         img_model_adv.data_dict_keys = []
-                        img_model_adv.data_dict_keys = img_model_adv.data_dict.keys()
+                        img_model_adv.data_dict_keys = list(img_model_adv.data_dict.keys())
                         img_model_rgb.data_dict_keys = []
-                        img_model_rgb.data_dict_keys = img_model_rgb.data_dict.keys()
+                        img_model_rgb.data_dict_keys = list(img_model_rgb.data_dict.keys())
 
                         #img_model_adv.set_initial_stat()
 
@@ -95,12 +102,18 @@ enamldef SettingView(DockItem):
                                 #maximum_size = 140
                                 minimum = 0
                                 maximum = 100000
+                                value ::
+                                    if plot_model and (loop_item in plot_model.roi_dict):
+                                        plot_model.plot_roi_bound()
                             SpinBox: right_v:
                                 value := setting_model.roi_dict[loop_item].right_val
                                 single_step = setting_model.roi_dict[loop_item].step
                                 #maximum_size = 140
                                 minimum = 0
                                 maximum = 100000
+                                value ::
+                                    if plot_model and (loop_item in plot_model.roi_dict):
+                                        plot_model.plot_roi_bound()
                             PushButton: view_btn:
                                 text = 'Add Plot'
                                 #maximum_size = 100
@@ -121,5 +134,11 @@ enamldef SettingView(DockItem):
                             PushButton: default_btn:
                                 text = 'Use Default'
                                 clicked ::
-                                    plot_model.roi_dict[loop_item].left_val = plot_model.roi_dict[loop_item].default_left
-                                    plot_model.roi_dict[loop_item].right_val = plot_model.roi_dict[loop_item].default_right
+                                    # Reset values to default
+                                    if loop_item in setting_model.roi_dict:
+                                        setting_model.roi_dict[loop_item].left_val = setting_model.roi_dict[loop_item].default_left
+                                        setting_model.roi_dict[loop_item].right_val = setting_model.roi_dict[loop_item].default_right
+                                    if plot_model and (loop_item in plot_model.roi_dict):
+                                        plot_model.roi_dict[loop_item].left_val = plot_model.roi_dict[loop_item].default_left
+                                        plot_model.roi_dict[loop_item].right_val = plot_model.roi_dict[loop_item].default_right
+                                        # plot_model.plot_roi_bound()

--- a/pyxrf/view/setting.enaml
+++ b/pyxrf/view/setting.enaml
@@ -28,7 +28,7 @@ enamldef SettingView(DockItem):
                     hbox(setup_lbl, spacer, clear_element_list, use_selected),
                     hbox(element_fd),
                     scroller,
-                    hbox(prefix_lbl, prefix_fd, sub_background, spacer, calculate_btn),
+                    hbox(sub_background, spacer, calculate_btn),
                 ),
                 #folder_btn.width == files_btn.width,
             ]
@@ -52,11 +52,6 @@ enamldef SettingView(DockItem):
                     setting_model.select_elements_from_list(selected_element_list)
             Field: element_fd:
                 text := setting_model.element_for_roi
-            Label: prefix_lbl:
-                text = 'Label'
-            Field: prefix_fd:
-                text := setting_model.prefix_name_roi
-                submit_triggers = ['auto_sync']
             CheckBox: sub_background:
                 text = 'Subtract background'
                 checked := setting_model.subtract_background
@@ -66,8 +61,6 @@ enamldef SettingView(DockItem):
                 clicked ::
                     if len(setting_model.element_for_roi) == 0:
                         warning(self, 'Warning Dialog', 'Please select at least one element.')
-                    elif len(setting_model.prefix_name_roi) == 0:
-                        warning(self, 'Warning Dialog', 'Please enter Label name.')
                     else:
                         #box = MessageBox()
                         #box.title = 'Warning Message'

--- a/pyxrf/view/setting.enaml
+++ b/pyxrf/view/setting.enaml
@@ -11,6 +11,7 @@ from enaml.stdlib.fields import FloatField
 from enaml.stdlib.message_box import MessageBox, warning, information
 
 import numpy as np
+import time
 
 enamldef SettingView(DockItem):
     attr io_model
@@ -27,7 +28,7 @@ enamldef SettingView(DockItem):
                     hbox(setup_lbl, spacer, clear_element_list, use_selected),
                     hbox(element_fd),
                     scroller,
-                    hbox(prefix_lbl, prefix_fd, spacer, calculate_btn),
+                    hbox(prefix_lbl, prefix_fd, sub_background, spacer, calculate_btn),
                 ),
                 #folder_btn.width == files_btn.width,
             ]
@@ -36,10 +37,17 @@ enamldef SettingView(DockItem):
             PushButton: clear_element_list:
                 text = 'Clear'
                 clicked ::
+                    for r in setting_model.element_list_roi:
+                        plot_model.roi_dict[r].show_plot = False
+                    plot_model.plot_roi_bound()
                     setting_model.clear_selected_elements()
             PushButton: use_selected:
                 text = 'Use lines selected for fitting'
+                enabled << param_model.n_selected_pure_elines_for_fitting > 0
                 clicked ::
+                    for r in setting_model.element_list_roi:
+                        plot_model.roi_dict[r].show_plot = False
+                    plot_model.plot_roi_bound()
                     selected_element_list = param_model.EC.get_element_list()
                     setting_model.select_elements_from_list(selected_element_list)
             Field: element_fd:
@@ -49,14 +57,17 @@ enamldef SettingView(DockItem):
             Field: prefix_fd:
                 text := setting_model.prefix_name_roi
                 submit_triggers = ['auto_sync']
+            CheckBox: sub_background:
+                text = 'Subtract background'
+                checked := setting_model.subtract_background
             PushButton: calculate_btn:
                 text = 'Calculate ROI'
                 enabled << setting_model.enable_roi_computation
                 clicked ::
                     if len(setting_model.element_for_roi) == 0:
-                        warning(self, 'Warning Dialog', 'Please enter element first.')
+                        warning(self, 'Warning Dialog', 'Please select at least one element.')
                     elif len(setting_model.prefix_name_roi) == 0:
-                        warning(self, 'Warning Dialog', 'Please enter prefix name first.')
+                        warning(self, 'Warning Dialog', 'Please enter prefix name.')
                     else:
                         #box = MessageBox()
                         #box.title = 'Warning Message'
@@ -73,6 +84,12 @@ enamldef SettingView(DockItem):
                         img_model_rgb.data_dict_keys = list(img_model_rgb.data_dict.keys())
 
                         #img_model_adv.set_initial_stat()
+
+                        time.sleep(1)  # 1 s. delay for ergonomic purposes (computations are instant)
+                        information(self, "Job Completed",
+                                    "ROI are successfully computed. Use 'Element Map' "
+                                    "and 'Element RGB' tabs to view the results")
+
 
             ScrollArea: scroller:
                 #Form:
@@ -115,22 +132,21 @@ enamldef SettingView(DockItem):
                                     if plot_model and (loop_item in plot_model.roi_dict):
                                         plot_model.plot_roi_bound()
                             PushButton: view_btn:
-                                text = 'Add Plot'
+                                # text = 'Add Plot'
+                                text << 'Remove' if plot_model.roi_dict[loop_item].show_plot \
+                                                   else 'Add Plot'
                                 #maximum_size = 100
                                 checkable = True
                                 checked := setting_model.roi_dict[loop_item].show_plot
                                 clicked ::
                                     plot_model.roi_dict = setting_model.roi_dict
                                     if checked:
+                                        plot_model.plot_exp_opt = True
                                         plot_model.roi_dict[loop_item].show_plot = True
-                                        #plot_model.roi_dict = setting_model.roi_dict
                                         plot_model.plot_roi_bound()
-                                        view_btn.text = 'Remove'
                                     else:
                                         plot_model.roi_dict[loop_item].show_plot = False
-                                        #plot_model.roi_dict = setting_model.roi_dict
                                         plot_model.plot_roi_bound()
-                                        view_btn.text = 'Add Plot'
                             PushButton: default_btn:
                                 text = 'Use Default'
                                 clicked ::


### PR DESCRIPTION
Implemented and fixed features include:

-- direct loading data from databroker by scan ID is working. Remotely tested on SRX, HXN and TES.

-- improved consistency of behavior of ``make_hdf`` and ``pyxrf_batch`` functions. Both functions will raise exception if error occurred during the processing if called for a single scan/file or go to processing the next scan/file if the list of files or range of scan IDs is provided. ``make_hdf`` will also may detect 'incomplete' scans that have no stop document.

-- fixed and improved functionality of ``ROI setting`` tab, which allows to compute ROIs. All features are operational and stable. Added an option to subtract background from raw data before computing ROIs.

-- fixed minor stability issues, including program crash when removing all selected lines using ``Delete not selected items`` or ``Delete Rel Int`` buttons in ``Fit`` tab.

-- working directory is now set at start-up of PyXRF to current working directory.

-- calculated ROIs are saved in the HDF5 files. Separate set of ROIs are saved for each dataset (such as ``sum``, ``det1``, ``det2`` etc.

-- all processing results contained in HDF5 file are always loaded. For example, if fitting or ROI results for ``det2`` are saved in an HDF5 file, they will be loaded and available for viewing even if raw data from individual detector channels is not loaded (only ``sum `` is loaded).

-- buttons ``<`` and ``>`` are added to ``Fit`` and ``Spectrum View`` tab to switch between element emission lines (possible fix for issue with MacOS version of PyXRF, in which ComboBox doesn't seem to keep focus and swiching using Up and Down arrows does not work reliably).    