### PR TITLE
GUI: tools for setting parameters of user defined peaks

### DIFF
--- a/pyxrf/gui.py
+++ b/pyxrf/gui.py
@@ -78,7 +78,7 @@ def run():
     io_model = FileIOModel(**defaults)
     param_model = GuessParamModel(**defaults)
     plot_model = LinePlotModel(param_model=param_model)
-    fit_model = Fit1D(**defaults)
+    fit_model = Fit1D(param_model=param_model, **defaults)
     setting_model = SettingModel(**defaults)
     img_model_adv = DrawImageAdvanced()
     img_model_rgb = DrawImageRGB()

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -370,7 +370,7 @@ class Fit1D(Atom):
                     self.name_userpeak_area = ""
 
                 if self.name_userpeak_dcenter and self.name_userpeak_dsigma:
-                    # Userpeak always has energy of 5.0 kEv, the user can set only the offset
+                    # Userpeak always has energy of 5.0 keV, the user can set only the offset
                     #   This is the internal representation, but we must display and let the user
                     #   enter the true value of energy
                     self.add_userpeak_energy = \

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -313,12 +313,12 @@ class Fit1D(Atom):
                     # Userpeak always has energy of 5.0 kEv, the user can set only the offset
                     #   This is the internal representation, but we must display and let the user
                     #   enter the true value of energy
-                    self.add_userpeak_energy_noupdate = True  # Don't redraw the plot
+                    #self.add_userpeak_energy_noupdate = True  # Don't run extra calculations
                     self.add_userpeak_energy = \
                         self.param_dict[self.name_userpeak_energy]["value"] + 5.0
                     # Same with FWHM for the user defined peak.
                     #   Also, sigma must be converted to FWHM: FWHM = 2.355 * sigma
-                    self.add_userpeak_fwhm_noupdate = True  # Don't redraw the plot
+                    #self.add_userpeak_fwhm_noupdate = True  # Don't run extra calculations
                     self.add_userpeak_fwhm = \
                         self.param_dict[self.name_userpeak_fwhm]["value"] * 2.355 + \
                         self.param_model.default_parameters["fwhm_fanoprime"]["value"] + \
@@ -342,8 +342,11 @@ class Fit1D(Atom):
             self.add_userpeak_energy_noupdate = False
             return
 
-        self.param_dict[self.name_userpeak_energy]["value"] = \
-            self.add_userpeak_energy - 5.0
+        energy = self.add_userpeak_energy - 5.0
+        self.param_dict[self.name_userpeak_energy]["value"] = energy
+        self.param_dict[self.name_userpeak_energy]["max"] = energy + 0.005
+        self.param_dict[self.name_userpeak_energy]["min"] = energy - 0.005
+
 
     @observe('add_userpeak_fwhm')
     def _update_userpeak_fwhm(self, change):
@@ -356,11 +359,14 @@ class Fit1D(Atom):
             self.add_userpeak_fwhm_noupdate = False
             return
 
-        v = self.add_userpeak_fwhm - \
-            self.param_model.default_parameters["fwhm_fanoprime"]["value"] - \
+        fwhm = self.param_model.default_parameters["fwhm_fanoprime"]["value"] - \
             self.param_model.default_parameters["fwhm_offset"]["value"]
 
-        self.param_dict[self.name_userpeak_fwhm]["value"] = v / 2.355
+        fwhm = (self.add_userpeak_fwhm - fwhm) / 2.355
+
+        self.param_dict[self.name_userpeak_fwhm]["value"] = fwhm
+        self.param_dict[self.name_userpeak_fwhm]["max"] = fwhm + 0.02
+        self.param_dict[self.name_userpeak_fwhm]["min"] = fwhm - 0.02
 
     def keep_size(self):
         """Keep the size of deque as 2.

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -152,14 +152,13 @@ class Fit1D(Atom):
     add_userpeak_energy = Float(0.0)
     add_userpeak_fwhm = Float(0.0)
     # Copies of the variables that hold old value during update
-    #add_userpeak_energy_old = Float(0.0)
-    #add_userpeak_fwhm_old = Float(0.0)
+    add_userpeak_fwhm_old = Float(0.0)
     # The names for the respective parameters
     #   (used to access parameters in
     #   self.param_model.param_dict)
-    name_userpeak_energy = Str()
-    name_userpeak_fwhm = Str()
-    #name_userpeak_area = Str()
+    name_userpeak_dcenter = Str()
+    name_userpeak_dsigma = Str()
+    name_userpeak_area = Str()
 
     def __init__(self, param_model, *args, **kwargs):
         self.working_directory = kwargs['working_directory']
@@ -275,7 +274,11 @@ class Fit1D(Atom):
     @observe('selected_index')
     def _selected_element_changed(self, change):
         if change['value'] > 0:
-            selected_element = self.element_list[change['value']-1]
+            ind_sel = change['value'] - 1
+            if ind_sel >= len(self.element_list):
+                ind_sel = len(self.element_list) - 1
+                self.selected_index = ind_sel + 1  # Change the selection as well
+            selected_element = self.element_list[ind_sel]
             if len(selected_element) <= 4:
                 element = selected_element.split('_')[0]
                 self.elementinfo_list = sorted([e for e in list(self.param_dict.keys())
@@ -297,7 +300,38 @@ class Fit1D(Atom):
         v_const = 2 * np.sqrt(2 * np.log(2))
         sigma = self.param_model.default_parameters["fwhm_offset"]["value"] / v_const
 
-        sigma_sqr = self.param_dict[self.name_userpeak_energy]["value"] + 5.0  # center
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # The error was detected in scikit-beam, but not corrected
+        # Note: Corrections are required in the function ``element_peak_xrf``
+        #   from file ``xrf_model.py`` (package Scikit-Beam)
+        # The error: the original center position for the peak was used to
+        #   compute sigma of the Gaussian approximation of the peak. It almost not matter
+        #   for element peaks, since they don't move along the energy axis. But it is
+        #   invalid for Userpeaks, which are placed at a fixed position (5 keV) and then
+        #   moved to the desired position by changing ``delta_center``. Sigma depends
+        #   on actual center position, so ``delta_center`` should be taken into account.
+        #
+        # The original code for computing Gaussian function:
+        # def get_sigma(center):
+        #     temp_val = 2 * np.sqrt(2 * np.log(2))
+        #     return np.sqrt((fwhm_offset / temp_val) ** 2 + center * epsilon * fwhm_fanoprime)
+        #
+        # x = e_offset + x * e_linear + x ** 2 * e_quadratic
+        #
+        # return gaussian(x, area, center + delta_center,
+        #                 delta_sigma + get_sigma(center)) * ratio * ratio_adjust
+        #
+        # To correct the error, the last statement should be changed to the following:
+        # return gaussian(x, area, center + delta_center,
+        #                 delta_sigma + get_sigma(center + delta_center)) * ratio * ratio_adjust
+
+        # Temporary fix for the error mentioned above (to keep peak hight consistent as it moves
+        #   along the enery axis, computation of sigma must be identical here and in
+        #   the function ``element_peak_xrf``
+        sigma_sqr = 5.0  # center (ignore ``delta_sigma``)
+        # Correct line (but may be enabled only if the bug in scikit-beam is corrected)
+        #sigma_sqr = self.param_dict[self.name_userpeak_dcenter]["value"] + 5.0  # center
+
         sigma_sqr *= self.param_model.default_parameters["non_fitting_values"]["epsilon"]  # epsilon
         sigma_sqr *= self.param_model.default_parameters["fwhm_fanoprime"]["value"]  # fanoprime
         sigma_sqr += sigma * sigma  # We have computed the expression under sqrt
@@ -316,12 +350,12 @@ class Fit1D(Atom):
         v_const = 2 * np.sqrt(2 * np.log(2))
         return fwhm / v_const
 
-    def _area_from_max(self, peak_max, peak_sigma):
+    def _gaussian_max_to_area(self, peak_max, peak_sigma):
         # Returns the area of Gaussian peak for the given maximum and sigma
         s2pi = np.sqrt(2 * np.pi)
         return peak_max * s2pi * peak_sigma
 
-    def _max_from_area(self, peak_area, peak_sigma):
+    def _gaussian_area_to_max(self, peak_area, peak_sigma):
         # Returns maximum of the area of Gaussian peak for the given peak area and sigma
         s2pi = np.sqrt(2 * np.pi)
         if peak_sigma == 0:
@@ -340,40 +374,40 @@ class Fit1D(Atom):
             if "Userpeak" in eline_name:
                 names = [name for name in self.elementinfo_list if "_delta_center" in name]
                 if names:
-                    self.name_userpeak_energy = names[0]
+                    self.name_userpeak_dcenter = names[0]
                 else:
-                    self.name_userpeak_energy = ""
+                    self.name_userpeak_dcenter = ""
 
                 names = [name for name in self.elementinfo_list if "_delta_sigma" in name]
                 if names:
-                    self.name_userpeak_fwhm = names[0]
+                    self.name_userpeak_dsigma = names[0]
                 else:
-                    self.name_userpeak_fwhm = ""
+                    self.name_userpeak_dsigma = ""
 
-                #names = [name for name in self.elementinfo_list if "_area" in name]
-                #if names:
-                #    self.name_userpeak_area = names[0]
-                #else:
-                #    self.name_userpeak_area = ""
+                names = [name for name in self.elementinfo_list if "_area" in name]
+                if names:
+                    self.name_userpeak_area = names[0]
+                else:
+                    self.name_userpeak_area = ""
 
-                if self.name_userpeak_energy and self.name_userpeak_fwhm:
+                if self.name_userpeak_dcenter and self.name_userpeak_dsigma:
                     # Userpeak always has energy of 5.0 kEv, the user can set only the offset
                     #   This is the internal representation, but we must display and let the user
                     #   enter the true value of energy
                     self.add_userpeak_energy = \
-                        self.param_dict[self.name_userpeak_energy]["value"] + 5.0
+                        self.param_dict[self.name_userpeak_dcenter]["value"] + 5.0
                     # Same with FWHM for the user defined peak.
                     #   Also, sigma must be converted to FWHM: FWHM = 2.355 * sigma
                     self.add_userpeak_fwhm = \
-                        self.param_dict[self.name_userpeak_fwhm]["value"] + \
+                        self._sigma_to_fwhm(self.param_dict[self.name_userpeak_dsigma]["value"]) + \
                         self._compute_fwhm_base()
 
-                    # Adjust formatting (5 digits after dot is sufficient
+                    # Create copies (before rounding)
+                    self.add_userpeak_fwhm_old = self.add_userpeak_fwhm
+
+                    # Adjust formatting (5 digits after dot is sufficient)
                     self.add_userpeak_energy = float(f"{self.add_userpeak_energy:.5f}")
                     self.add_userpeak_fwhm = float(f"{self.add_userpeak_fwhm:.5f}")
-                    # Create copies
-                    #self.add_userpeak_energy_old = self.add_userpeak_energy
-                    #self.add_userpeak_fwhm_old = self.add_userpeak_fwhm
 
         else:
             raise Exception(f"Line '{eline_name}' is not in the list of selected element lines.")
@@ -393,9 +427,9 @@ class Fit1D(Atom):
 
         # Now we change energy.
         energy = self.add_userpeak_energy - 5.0
-        self.param_dict[self.name_userpeak_energy]["value"] = energy
-        self.param_dict[self.name_userpeak_energy]["max"] = energy + 0.005
-        self.param_dict[self.name_userpeak_energy]["min"] = energy - 0.005
+        self.param_dict[self.name_userpeak_dcenter]["value"] = energy
+        self.param_dict[self.name_userpeak_dcenter]["max"] = energy + 0.005
+        self.param_dict[self.name_userpeak_dcenter]["min"] = energy - 0.005
 
         # The base value is updated now (since the energy has changed)
         fwhm_base = self._compute_fwhm_base()
@@ -412,46 +446,47 @@ class Fit1D(Atom):
         fwhm_base = self._compute_fwhm_base()
         fwhm = self.add_userpeak_fwhm - fwhm_base
 
-        self.param_dict[self.name_userpeak_fwhm]["value"] = fwhm
-        self.param_dict[self.name_userpeak_fwhm]["max"] = fwhm + 0.02
-        self.param_dict[self.name_userpeak_fwhm]["min"] = fwhm - 0.02
+        sigma = self._fwhm_to_sigma(fwhm)
+
+        self.param_dict[self.name_userpeak_dsigma]["value"] = sigma
+        self.param_dict[self.name_userpeak_dsigma]["max"] = sigma + 0.02
+        self.param_dict[self.name_userpeak_dsigma]["min"] = sigma - 0.02
 
     def update_userpeak(self):
         # Update current user peak. Called when 'Update peak' button is pressed.
 
         # Some checks of the input values
-        if self.add_userpeak_energy <= 0:
-            logger.warning("User peak energy must be a positive number.")
+        if self.add_userpeak_energy <= 0.0:
+            logger.warning("User peak energy must be a positive number greater than 0.001.")
             return
         if self.add_userpeak_fwhm <= 0:
             logger.warning("User peak FWHM must be a positive number.")
             return
 
-        # Find and save the value of peak maximum. Restore the maximum after FWHM is changed.
-        # Note, that ``peak_sigma`` and ``peak_area`` may change if energy changes,
-        #   but ``peak_max`` must remain the same (for better visual presentation)
-        #peak_sigma = self._fwhm_to_sigma(self.add_userpeak_fwhm_old)
-        #peak_area = self.param_dict[self.name_userpeak_area]["value"]
-        #peak_max = self._max_from_area(peak_area, peak_sigma)  # Keep this value
-
-        #print(f"Peak sigma before transformations: {peak_sigma}")
-        #print(f"Peak area before transformations: {peak_area}")
-        #print(f"Peak max (computed) before transformations: {peak_max}")
+        # Ensure, that the values are greater than some small value to ensure that
+        #   there is no computational problems
+        if self.add_userpeak_energy < 0.001:  # 1 eV is very small, the scale is in keV
+            self.add_userpeak_energy = 0.001
+        if self.add_userpeak_fwhm < 0.001:  # 1 eV FWHM is very small, energy axis has 10 eV step
+            self.add_userpeak_fwhm = 0.001
 
         self._update_userpeak_energy()
         self._update_userpeak_fwhm()
 
-        # Restore peak height by adjusting the area (for new fwhm)
-        #peak_sigma = self._fwhm_to_sigma(self.add_userpeak_fwhm)
-        #peak_area = self._area_from_max(peak_max, peak_sigma)
-        #self.param_dict[self.name_userpeak_area]["value"] = peak_area
+        # Find and save the value of peak maximum. Restore the maximum after FWHM is changed.
+        # Note, that ``peak_sigma`` and ``peak_area`` may change if energy changes,
+        #   but ``peak_max`` must remain the same (for better visual presentation)
+        peak_sigma = self._fwhm_to_sigma(self.add_userpeak_fwhm_old)
+        peak_area = self.param_dict[self.name_userpeak_area]["value"]
+        peak_max = self._gaussian_area_to_max(peak_area, peak_sigma)  # Keep this value
 
-        #print(f"Peak sigma after transformations: {peak_sigma}")
-        #print(f"Peak area after transformations: {peak_area}")
+        # Restore peak height by adjusting the area (for new fwhm)
+        peak_sigma = self._fwhm_to_sigma(self.add_userpeak_fwhm)
+        peak_area = self._gaussian_max_to_area(peak_max, peak_sigma)
+        self.param_dict[self.name_userpeak_area]["value"] = peak_area
 
         # Create copies
-        #self.add_userpeak_energy_old = self.add_userpeak_energy
-        #self.add_userpeak_fwhm_old = self.add_userpeak_fwhm
+        self.add_userpeak_fwhm_old = self.add_userpeak_fwhm
 
         logger.debug(f"The parameters of the user defined peak. The new values:\n"
                      f"          Energy: {self.add_userpeak_energy} keV\n"

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -329,8 +329,8 @@ class Fit1D(Atom):
         #   along the enery axis, computation of sigma must be identical here and in
         #   the function ``element_peak_xrf``
         sigma_sqr = 5.0  # center (ignore ``delta_sigma``)
-        # Correct line (but may be enabled only if the bug in scikit-beam is corrected)
-        #sigma_sqr = self.param_dict[self.name_userpeak_dcenter]["value"] + 5.0  # center
+        # The next line is correct (but may be enabled only if the bug in scikit-beam is corrected)
+        # sigma_sqr = self.param_dict[self.name_userpeak_dcenter]["value"] + 5.0  # center
 
         sigma_sqr *= self.param_model.default_parameters["non_fitting_values"]["epsilon"]  # epsilon
         sigma_sqr *= self.param_model.default_parameters["fwhm_fanoprime"]["value"]  # fanoprime
@@ -441,7 +441,6 @@ class Fit1D(Atom):
         self.add_userpeak_fwhm = fwhm
 
     def _update_userpeak_fwhm(self):
-
 
         fwhm_base = self._compute_fwhm_base()
         fwhm = self.add_userpeak_fwhm - fwhm_base

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -406,9 +406,14 @@ class Fit1D(Atom):
 
         # Now we change energy.
         energy = self.add_userpeak_energy - 5.0
+
+        v_center = self.param_dict[self.name_userpeak_dcenter]["value"]
+        v_max = self.param_dict[self.name_userpeak_dcenter]["max"]
+        v_min = self.param_dict[self.name_userpeak_dcenter]["min"]
+        # Keep the possible range for value change the same
         self.param_dict[self.name_userpeak_dcenter]["value"] = energy
-        self.param_dict[self.name_userpeak_dcenter]["max"] = energy + 0.005
-        self.param_dict[self.name_userpeak_dcenter]["min"] = energy - 0.005
+        self.param_dict[self.name_userpeak_dcenter]["max"] = energy + v_max - v_center
+        self.param_dict[self.name_userpeak_dcenter]["min"] = energy - (v_center - v_min)
 
         # The base value is updated now (since the energy has changed)
         fwhm_base = self._compute_fwhm_base()
@@ -426,9 +431,13 @@ class Fit1D(Atom):
 
         sigma = gaussian_fwhm_to_sigma(fwhm)
 
+        v_center = self.param_dict[self.name_userpeak_dsigma]["value"]
+        v_max = self.param_dict[self.name_userpeak_dsigma]["max"]
+        v_min = self.param_dict[self.name_userpeak_dsigma]["min"]
+        # Keep the possible range for value change the same
         self.param_dict[self.name_userpeak_dsigma]["value"] = sigma
-        self.param_dict[self.name_userpeak_dsigma]["max"] = sigma + 0.02
-        self.param_dict[self.name_userpeak_dsigma]["min"] = sigma - 0.02
+        self.param_dict[self.name_userpeak_dsigma]["max"] = sigma + v_max - v_center
+        self.param_dict[self.name_userpeak_dsigma]["min"] = sigma - (v_center - v_min)
 
     def update_userpeak(self):
         # Update current user peak. Called when 'Update peak' button is pressed.
@@ -442,11 +451,14 @@ class Fit1D(Atom):
             return
 
         # Ensure, that the values are greater than some small value to ensure that
-        #   there is no computational problems
-        if self.add_userpeak_energy < 0.001:  # 1 eV is very small, the scale is in keV
-            self.add_userpeak_energy = 0.001
-        if self.add_userpeak_fwhm < 0.001:  # 1 eV FWHM is very small, energy axis has 10 eV step
-            self.add_userpeak_fwhm = 0.001
+        #   there is no computational problems.
+        # Energy resolution for the existing beamlines is 0.01 keV, so 0.001 is small
+        #   enough both for center energy and FWHM.
+        energy_small_value = 0.001
+        if self.add_userpeak_energy < energy_small_value:
+            self.add_userpeak_energy = energy_small_value
+        if self.add_userpeak_fwhm < energy_small_value:
+            self.add_userpeak_fwhm = energy_small_value
 
         self._update_userpeak_energy()
         self._update_userpeak_fwhm()

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -490,6 +490,13 @@ class GuessParamModel(Atom):
                                                    elemental_lines=[self.e_name],
                                                    default_area=default_area)
 
+        # Check if element profile was calculated successfully.
+        #   Calculation may fail if the selected line is not activated.
+        #   The calculation is performed using ``xraylib` library, so there is no
+        #   control over it.
+        if not self.e_name in data_out:
+            raise Exception(f"Failed to add the emission line '{self.e_name}': line is not activated.")
+
         ratio_v = self.add_element_intensity / np.max(data_out[self.e_name])
 
         ps = PreFitStatus(z=get_Z(self.e_name),

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -251,8 +251,6 @@ class GuessParamModel(Atom):
     # total_pileup = Dict()
     e_name = Str()        # Element line name selected in combo box
     add_element_intensity = Float(1000.0)
-    add_userpeak_energy = Float(5000.0)
-    add_userpeak_fwhm = Float(1.0)
     element_list = List()
     # data_sets = Typed(OrderedDict)
     EC = Typed(object)

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -251,6 +251,8 @@ class GuessParamModel(Atom):
     # total_pileup = Dict()
     e_name = Str()        # Element line name selected in combo box
     add_element_intensity = Float(1000.0)
+    add_userpeak_energy = Float(5000.0)
+    add_userpeak_fwhm = Float(1.0)
     element_list = List()
     # data_sets = Typed(OrderedDict)
     EC = Typed(object)

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -492,7 +492,7 @@ class GuessParamModel(Atom):
         #   Calculation may fail if the selected line is not activated.
         #   The calculation is performed using ``xraylib` library, so there is no
         #   control over it.
-        if not self.e_name in data_out:
+        if self.e_name not in data_out:
             raise Exception(f"Failed to add the emission line '{self.e_name}': line is not activated.")
 
         ratio_v = self.add_element_intensity / np.max(data_out[self.e_name])

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -816,8 +816,10 @@ class LinePlotModel(Atom):
                 # Some default value
                 intensity = 1000.0
 
-                if self.data is not None and self.parameters is not None and \
-                        len(self.data) > 1 and len(self.param_model.prefit_x) > 1:
+                if self.data is not None and self.parameters is not None \
+                        and self.param_model.prefit_x is not None \
+                        and len(self.data) > 1 and len(self.param_model.prefit_x) > 1:
+
                     # Range of energies in fitting results
                     e_fit_min = self.param_model.prefit_x[0]
                     e_fit_max = self.param_model.prefit_x[-1]

--- a/pyxrf/model/utils.py
+++ b/pyxrf/model/utils.py
@@ -219,7 +219,7 @@ def gaussian_area_to_max(peak_area, peak_sigma):
     ----------
 
     peak_area : float
-        maximum of the Gaussian curve
+       area under the Gaussian curve
     peak_sigma : float
         sigma of the Gaussian curve
 

--- a/pyxrf/model/utils.py
+++ b/pyxrf/model/utils.py
@@ -147,7 +147,7 @@ def normalize_data_by_scaler(data_in, scaler, *, data_name=None, name_not_scalab
 
 
 # ===============================================================================
-# The following functions are prepared to be eventually moved to scikit-beam
+# The following functions are prepared to be moved to scikit-beam
 
 def _get_2_sqrt_2_log2():
     return 2 * np.sqrt(2 * np.log(2))

--- a/pyxrf/model/utils.py
+++ b/pyxrf/model/utils.py
@@ -144,3 +144,92 @@ def normalize_data_by_scaler(data_in, scaler, *, data_name=None, name_not_scalab
 
 
 # ===============================================================================
+
+
+# ===============================================================================
+# The following functions are prepared to be eventually moved to scikit-beam
+
+def _get_2_sqrt_2_log2():
+    return 2 * np.sqrt(2 * np.log(2))
+
+
+def gaussian_sigma_to_fwhm(sigma):
+    """
+    Converts parameters of Gaussian curve: 'sigma' to 'fwhm'
+
+    Parameters
+    ----------
+
+    sigma : float
+        sigma of the Gaussian curve
+
+    Returns
+    -------
+    FWHM of the Gaussian curve
+    """
+    return sigma * _get_2_sqrt_2_log2()
+
+
+def gaussian_fwhm_to_sigma(fwhm):
+    """
+    Converts parameters of Gaussian curve: 'fwhm' to 'sigma'
+
+    Parameters
+    ----------
+
+    fwhm : float
+        Full Width at Half Maximum of the Gaussian curve
+
+    Returns
+    -------
+    sigma of the Gaussian curve
+    """
+    return fwhm / _get_2_sqrt_2_log2()
+
+
+def _get_sqrt_2_pi():
+    return np.sqrt(2 * np.pi)
+
+
+def gaussian_max_to_area(peak_max, peak_sigma):
+    """
+    Computes the area under Gaussian curve based on maximum and sigma
+
+    Parameters
+    ----------
+
+    peak_max : float
+        maximum of the Gaussian curve
+    peak_sigma : float
+        sigma of the Gaussian curve
+
+    Returns
+    -------
+    area under the Gaussian curve
+    """
+    return peak_max * peak_sigma * _get_sqrt_2_pi()
+
+
+def gaussian_area_to_max(peak_area, peak_sigma):
+    """
+    Computes the maximum of the Gaussian curve based on area
+    under the curve and sigma
+
+    Parameters
+    ----------
+
+    peak_area : float
+        maximum of the Gaussian curve
+    peak_sigma : float
+        sigma of the Gaussian curve
+
+    Returns
+    -------
+    area under the Gaussian curve
+    """
+    if peak_sigma == 0:
+        return 0
+    else:
+        return peak_area / peak_sigma / _get_sqrt_2_pi()
+
+# ==================================================================================

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -179,7 +179,7 @@ enamldef FitView(DockItem): fit_view:
                 vbox(
                     hbox(eline_selection, intensity_lb, intensity_fd,
                          manual_add, manual_remove, spacer, pb_pileup),
-                    hbox(spacer, lb_userpeak_energy, fd_userpeak_energy, lb_userpeak_fwhm, fd_userpeak_fwhm),
+                    hbox(spacer, lb_userpeak_energy, fd_userpeak_energy, lb_userpeak_fwhm, fd_userpeak_fwhm, pb_userpeak_update),
                     pre_fit,
                 ),
             ]
@@ -295,16 +295,6 @@ enamldef FitView(DockItem): fit_view:
                 maximum_size = 80
                 visible << "Userpeak" in cb_select.selected_item and plot_model.allow_remove_eline_fit
                 value := fit_model.add_userpeak_energy
-                value ::
-                    calculate_spectrum_helper(fit_model, plot_model,
-                                              param_model, setting_model)
-
-                    # apply_to_fit(param_model, plot_model, fit_model, setting_model)
-
-                    #param_model.data_for_plot()
-                    #plot_model.plot_fit(param_model.prefit_x,
-                    #                    param_model.total_y,
-                    #                    param_model.auto_fit_all)
 
             Label: lb_userpeak_fwhm:
                 text = 'FWHM'
@@ -314,16 +304,25 @@ enamldef FitView(DockItem): fit_view:
                 maximum_size = 80
                 visible << "Userpeak" in cb_select.selected_item and plot_model.allow_remove_eline_fit
                 value := fit_model.add_userpeak_fwhm
-                value ::
+
+            PushButton: pb_userpeak_update:
+                text = 'Update peak'
+                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_remove_eline_fit
+                clicked ::
+                    # Save peak maximum value
+                    selected_eline = cb_select.selected_item
+                    peak_value = param_model.EC.element_dict[selected_eline].maxv
+                    fit_model.update_userpeak()
+
                     calculate_spectrum_helper(fit_model, plot_model,
                                               param_model, setting_model)
 
-                    # apply_to_fit(param_model, plot_model, fit_model, setting_model)
+                    # Restore peak maximum value
+                    param_model.EC.element_dict[selected_eline].maxv = peak_value
 
-                    #param_model.data_for_plot()
-                    #plot_model.plot_fit(param_model.prefit_x,
-                    #                    param_model.total_y,
-                    #                    param_model.auto_fit_all)
+                    apply_to_fit(param_model, plot_model, fit_model, setting_model)
+                    calculate_spectrum_helper(fit_model, plot_model,
+                                              param_model, setting_model)
 
             GroupBox: pre_fit:
                 padding = Box(2, 2, 2, 2)
@@ -448,10 +447,11 @@ enamldef FitView(DockItem): fit_view:
                                     submit_triggers = ['return_pressed']
                                     value ::
                                         param_model.EC.element_dict[loop_item].maxv = value
+                                        # if loop_item == cb_select.selected_item:
+                                        #     param_model.add_element_intensity = value
                                         apply_to_fit(param_model, plot_model, fit_model, setting_model)
                                         calculate_spectrum_helper(fit_model, plot_model,
                                                                   param_model, setting_model)
-
                                 Label: lb_norm:
                                     text << set_low_bound(np.around(param_model.EC.element_dict[loop_item].norm, 2))
                                     minimum_size = (60, 20)

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -317,13 +317,6 @@ enamldef FitView(DockItem): fit_view:
                     calculate_spectrum_helper(fit_model, plot_model,
                                               param_model, setting_model)
 
-                    # Restore peak maximum value
-                    param_model.EC.element_dict[selected_eline].maxv = peak_value
-
-                    apply_to_fit(param_model, plot_model, fit_model, setting_model)
-                    calculate_spectrum_helper(fit_model, plot_model,
-                                              param_model, setting_model)
-
             GroupBox: pre_fit:
                 padding = Box(2, 2, 2, 2)
                 constraints = [vbox(scr_area_title,

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -219,6 +219,11 @@ enamldef FitView(DockItem): fit_view:
                     index ::
                         if cb_select.index > 0:
                             param_model.e_name = cb_select.selected_item
+                            try:
+                                if "Userpeak" in cb_select.selected_item:
+                                    fit_model.select_index_by_eline_name(cb_select.selected_item)
+                            except Exception as ex:
+                                pass
 
             Label: intensity_lb:
                 text = 'Peak Int'
@@ -252,6 +257,16 @@ enamldef FitView(DockItem): fit_view:
                             btns = [DialogButton('Ok', 'accept')]
                             critical(self, 'ERROR', str(ex), btns)
 
+                        try:
+                            if "Userpeak" in cb_select.selected_item:
+                                fit_model.select_index_by_eline_name(cb_select.selected_item)
+                                param_model.data_for_plot()
+                                plot_model.plot_fit(param_model.prefit_x,
+                                                    param_model.total_y,
+                                                    param_model.auto_fit_all)
+                        except Exception as ex:
+                            pass
+
                         cb_select.set_focus()  # Return focus to the combo box
 
             PushButton: manual_remove:
@@ -274,21 +289,35 @@ enamldef FitView(DockItem): fit_view:
 
             Label: lb_userpeak_energy:
                 text = 'Energy'
-                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_add_eline_fit
+                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_remove_eline_fit
 
             FloatField: fd_userpeak_energy:
-                value := param_model.add_userpeak_energy
                 maximum_size = 80
-                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_add_eline_fit
+                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_remove_eline_fit
+                value := fit_model.add_userpeak_energy
+                value ::
+                    apply_to_fit(param_model, plot_model, fit_model, setting_model)
+
+                    #param_model.data_for_plot()
+                    #plot_model.plot_fit(param_model.prefit_x,
+                    #                    param_model.total_y,
+                    #                    param_model.auto_fit_all)
 
             Label: lb_userpeak_fwhm:
                 text = 'FWHM'
-                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_add_eline_fit
+                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_remove_eline_fit
 
             FloatField: fd_userpeak_fwhm:
-                value := param_model.add_userpeak_fwhm
                 maximum_size = 80
-                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_add_eline_fit
+                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_remove_eline_fit
+                value := fit_model.add_userpeak_fwhm
+                value ::
+                    apply_to_fit(param_model, plot_model, fit_model, setting_model)
+
+                    #param_model.data_for_plot()
+                    #plot_model.plot_fit(param_model.prefit_x,
+                    #                    param_model.total_y,
+                    #                    param_model.auto_fit_all)
 
             GroupBox: pre_fit:
                 padding = Box(2, 2, 2, 2)

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -296,7 +296,10 @@ enamldef FitView(DockItem): fit_view:
                 visible << "Userpeak" in cb_select.selected_item and plot_model.allow_remove_eline_fit
                 value := fit_model.add_userpeak_energy
                 value ::
-                    apply_to_fit(param_model, plot_model, fit_model, setting_model)
+                    calculate_spectrum_helper(fit_model, plot_model,
+                                              param_model, setting_model)
+
+                    # apply_to_fit(param_model, plot_model, fit_model, setting_model)
 
                     #param_model.data_for_plot()
                     #plot_model.plot_fit(param_model.prefit_x,
@@ -312,7 +315,10 @@ enamldef FitView(DockItem): fit_view:
                 visible << "Userpeak" in cb_select.selected_item and plot_model.allow_remove_eline_fit
                 value := fit_model.add_userpeak_fwhm
                 value ::
-                    apply_to_fit(param_model, plot_model, fit_model, setting_model)
+                    calculate_spectrum_helper(fit_model, plot_model,
+                                              param_model, setting_model)
+
+                    # apply_to_fit(param_model, plot_model, fit_model, setting_model)
 
                     #param_model.data_for_plot()
                     #plot_model.plot_fit(param_model.prefit_x,
@@ -441,7 +447,10 @@ enamldef FitView(DockItem): fit_view:
                                     minimum = 0.00001
                                     submit_triggers = ['return_pressed']
                                     value ::
+                                        param_model.EC.element_dict[loop_item].maxv = value
                                         apply_to_fit(param_model, plot_model, fit_model, setting_model)
+                                        calculate_spectrum_helper(fit_model, plot_model,
+                                                                  param_model, setting_model)
 
                                 Label: lb_norm:
                                     text << set_low_bound(np.around(param_model.EC.element_dict[loop_item].norm, 2))

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -177,41 +177,48 @@ enamldef FitView(DockItem): fit_view:
             padding = Box(2, 2, 2, 2)
             constraints = [
                 vbox(
-                    hbox(btn_cb_prev, btn_cb_next, cb_select, intensity_lb, intensity_fd,
+                    hbox(eline_selection, intensity_lb, intensity_fd,
                          manual_add, manual_remove, spacer, pb_pileup),
                     pre_fit,
                     #hbox(saveas_btn, spacer),
                 ),
             ]
-            ComboBox: cb_select:
-                #items = ['Select Lines'] +\
-                #        K_LINE + L_LINE + M_LINE + userpeak_list
-                items = ['Select Lines'] + param_model.get_user_peak_list(include_user_peaks=True)
-                index = 0
-                index := plot_model.element_id
-                enabled << plot_model.allow_select_elines
-                index ::
-                    if cb_select.index > 0:
-                        param_model.e_name = cb_select.selected_item
+            Container: eline_selection:
+                constraints = [
+                    contents_left == btn_cb_prev.left,
+                    btn_cb_prev.right+2 == btn_cb_next.left,
+                    btn_cb_next.right+5 == cb_select.left,
+                    cb_select.right == contents_right,
+                ]
 
-            PushButton: btn_cb_prev:
-                text = '<'
-                enabled << plot_model.allow_select_elines
-                maximum_size = (15, 24)
-                clicked ::
-                    if cb_select.index > 1:
-                        cb_select.index -= 1
-                    cb_select.set_focus()  # Return focus to the combo box
+                PushButton: btn_cb_prev:
+                    text = '<'
+                    enabled << plot_model.allow_select_elines
+                    maximum_size = (15, 24)
+                    clicked ::
+                        if cb_select.index > 1:
+                            cb_select.index -= 1
+                        cb_select.set_focus()  # Return focus to the combo box
 
+                PushButton: btn_cb_next:
+                    text = '>'
+                    enabled << plot_model.allow_select_elines
+                    maximum_size = (15, 24)
+                    clicked ::
+                        if cb_select.index < len(cb_select.items) - 1:
+                            cb_select.index += 1
+                        cb_select.set_focus()  # Return focus to the combo box
 
-            PushButton: btn_cb_next:
-                text = '>'
-                enabled << plot_model.allow_select_elines
-                maximum_size = (15, 24)
-                clicked ::
-                    if cb_select.index < len(cb_select.items) - 1:
-                        cb_select.index += 1
-                    cb_select.set_focus()  # Return focus to the combo box
+                ComboBox: cb_select:
+                    #items = ['Select Lines'] +\
+                    #        K_LINE + L_LINE + M_LINE + userpeak_list
+                    items = ['Select Lines'] + param_model.get_user_peak_list(include_user_peaks=True)
+                    index = 0
+                    index := plot_model.element_id
+                    enabled << plot_model.allow_select_elines
+                    index ::
+                        if cb_select.index > 0:
+                            param_model.e_name = cb_select.selected_item
 
             Label: intensity_lb:
                 text = 'Peak Int'

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -240,8 +240,18 @@ enamldef FitView(DockItem): fit_view:
                         critical(self, 'ERROR', f'Experimental data is not loaded or initial spectrum fitting is not performed', btns)
 
                     else:
+                        try:
+                            plot_model.add_peak_manual()
+                            # ``apply_to_fit`` takes some time to execute, so do it only for the user defined peaks
+                            #   After calling ``apply_to_fit``, the line parameters may be edited
+                            #   For other lines, the button ``Update`` must be pressed first.
+                            if "Userpeak" in cb_select.selected_item:
+                                apply_to_fit(param_model, plot_model, fit_model, setting_model)
 
-                        plot_model.add_peak_manual()
+                        except Exception as ex:
+                            btns = [DialogButton('Ok', 'accept')]
+                            critical(self, 'ERROR', str(ex), btns)
+
                         cb_select.set_focus()  # Return focus to the combo box
 
             PushButton: manual_remove:

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -179,8 +179,8 @@ enamldef FitView(DockItem): fit_view:
                 vbox(
                     hbox(eline_selection, intensity_lb, intensity_fd,
                          manual_add, manual_remove, spacer, pb_pileup),
+                    hbox(spacer, lb_userpeak_energy, fd_userpeak_energy, lb_userpeak_fwhm, fd_userpeak_fwhm),
                     pre_fit,
-                    #hbox(saveas_btn, spacer),
                 ),
             ]
             Container: eline_selection:
@@ -261,6 +261,24 @@ enamldef FitView(DockItem): fit_view:
                         btns = [DialogButton('Ok', 'accept')]
                         # 'critical' shows MessageBox
                         critical(self, 'ERROR', f'Experimental data is not loaded or initial spectrum fitting is not performed', btns)
+
+            Label: lb_userpeak_energy:
+                text = 'Energy'
+                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_add_eline_fit
+
+            FloatField: fd_userpeak_energy:
+                value := param_model.add_userpeak_energy
+                maximum_size = 80
+                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_add_eline_fit
+
+            Label: lb_userpeak_fwhm:
+                text = 'FWHM'
+                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_add_eline_fit
+
+            FloatField: fd_userpeak_fwhm:
+                value := param_model.add_userpeak_fwhm
+                maximum_size = 80
+                visible << "Userpeak" in cb_select.selected_item and plot_model.allow_add_eline_fit
 
             GroupBox: pre_fit:
                 padding = Box(2, 2, 2, 2)

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -10,6 +10,9 @@ from atom.api import *
 from ..model.lineplot import LinePlotModel
 from pyxrf.model.fileio import print_image
 
+from enaml.stdlib.dialog_buttons import DialogButton
+from enaml.stdlib.message_box import critical
+
 import numpy as np
 from matplotlib.figure import Figure
 from skbeam.core.fitting.xrf_model import (K_LINE, L_LINE, M_LINE)
@@ -47,7 +50,8 @@ enamldef PlotMain(DockItem):
         constraints = [
             vbox(
                 hbox(plot_exp_btn, pb_plot_fit, spacer, pb_print),
-                hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, cbox2, btn_cb_prev, btn_cb_next, checkb),
+                #hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, cbox2, btn_cb_prev, btn_cb_next, checkb),
+                hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, eline_selection, checkb),
                 canvas,
             ),
         ]
@@ -70,8 +74,17 @@ enamldef PlotMain(DockItem):
             text = 'Add line'
             enabled << plot_model.allow_add_eline and plot_model.plot_exp_opt
             clicked ::
-                plot_model.add_peak_manual()
-                cbox2.set_focus()  # Return focus to the combo box
+                # The following set of conditions is not complete, but sufficient
+                if param_model.x0 is None or param_model.y0 is None:
+
+                    btns = [DialogButton('Ok', 'accept')]
+                    # 'critical' shows MessageBox
+                    critical(self, 'ERROR', f'Experimental data is not loaded or initial spectrum fitting is not performed', btns)
+
+                else:
+
+                    plot_model.add_peak_manual()
+                    cbox2.set_focus()  # Return focus to the combo box
 
         PushButton: remove_eline:
             text = 'Remove line'
@@ -80,35 +93,43 @@ enamldef PlotMain(DockItem):
                 plot_model.remove_peak_manual(param_model.e_name)
                 cbox2.set_focus()  # Return focus to the combo box
 
-        ComboBox: cbox2:
-            #items = ['<Display emission lines>'] +\
-            #        K_LINE + L_LINE + M_LINE
-            items = ['<Display emission lines>'] + param_model.get_user_peak_list(include_user_peaks=False)
+        Container: eline_selection:
+            constraints = [
+                contents_left == cbox2.left,
+                cbox2.right+5 == btn_cb_prev.left,
+                btn_cb_prev.right+2 == btn_cb_next.left,
+                btn_cb_next.right == contents_right,
+            ]
 
-            index = 0
-            index := plot_model.element_id
-            enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt
-            index ::
-                if cbox2.index > 0:
-                    param_model.e_name = cbox2.selected_item
+            ComboBox: cbox2:
+                #items = ['<Display emission lines>'] +\
+                #        K_LINE + L_LINE + M_LINE
+                items = ['<Display emission lines>'] + param_model.get_user_peak_list(include_user_peaks=False)
 
-        PushButton: btn_cb_prev:
-            text = '<'
-            enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt
-            maximum_size = (15, 24)
-            clicked ::
-                if cbox2.index > 1:
-                    cbox2.index -= 1
-                cbox2.set_focus()  # Return focus to the combo box
+                index = 0
+                index := plot_model.element_id
+                enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt
+                index ::
+                    if cbox2.index > 0:
+                        param_model.e_name = cbox2.selected_item
 
-        PushButton: btn_cb_next:
-            text = '>'
-            enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt
-            maximum_size = (15, 24)
-            clicked ::
-                if cbox2.index < len(cbox2.items) - 1:
-                    cbox2.index += 1
-                cbox2.set_focus()  # Return focus to the combo box
+            PushButton: btn_cb_prev:
+                text = '<'
+                enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt
+                maximum_size = (15, 24)
+                clicked ::
+                    if cbox2.index > 1:
+                        cbox2.index -= 1
+                    cbox2.set_focus()  # Return focus to the combo box
+
+            PushButton: btn_cb_next:
+                text = '>'
+                enabled << plot_model.allow_select_elines and plot_model.plot_exp_opt
+                maximum_size = (15, 24)
+                clicked ::
+                    if cbox2.index < len(cbox2.items) - 1:
+                        cbox2.index += 1
+                    cbox2.set_focus()  # Return focus to the combo box
 
         PushButton: pb_print:
             text  ='Print'


### PR DESCRIPTION
Changes:

-- Better looking GUI tool for element line selection in ``Fit`` and ``Spectrum View`` tabs (combination of ``<``, ``>`` and element line selection ComboBox). Especially useful if PyXRF is used on MacOS.

-- Fixed program crash, which happens when element line is selected using ComboBoxes in ``Fit`` or ``Spectrum View`` tabs before initial fitting. Initial fitting is usually performed by running automated element search by clicking the ``Find Elements Automatically`` button in ``Fit`` tab. Now elements may be selected and element lines displayed in the ``Spectrum View`` tab before the initial fitting is done, but the elements may not be added to the list. If the ``Add`` button is pressed in ``Fit`` or ``Spectrum View`` tab befor the initial fitting is run, the Message Box offering to do the fitting is displayed to the user. In general, line selection tools are not intended to replace automated element search, but to edit the results of the search. This will be mentioned in the User Manual when documentation it going to be written.

-- Fixed program crash, which happens if an attempt to add an element line, which is not activated, is made. Now the line is not added and the MessageBox is displayed.

-- GUI elements for editing parameters (FWHM and center energy) of user defined peaks in ``Fit`` tab. The feature performs in such a way, that the maximum of the peak remains constant as the peak is moved along the energy axis and its FWHM is changed.