### PR TITLE
Option to overwrite existing files (make_hdf and PyXRF GUI)

### DIFF
--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -83,6 +83,11 @@ class FileIOModel(Atom):
     mask_opt = Int(0)
     load_each_channel = Bool(False)
 
+    # Used while loading data from database
+    # True: overwrite existing data file if it exists
+    # False: create new file with unique name (original name + version number)
+    file_overwrite_existing = Bool(False)
+
     p1_row = Int(-1)
     p1_col = Int(-1)
     p2_row = Int(-1)
@@ -217,7 +222,7 @@ class FileIOModel(Atom):
         #                                             self.fname_from_db,
         #                                             load_each_channel=self.load_each_channel)
 
-        rv = render_data_to_gui(self.runid)
+        rv = render_data_to_gui(self.runid, file_overwrite_existing=self.file_overwrite_existing)
 
         if rv is None:
             logger.error(f"Data from scan #{self.runid} was not loaded")
@@ -797,7 +802,7 @@ def read_hdf_APS(working_directory,
     return img_dict, data_sets
 
 
-def render_data_to_gui(runid):
+def render_data_to_gui(runid, *, file_overwrite_existing=False):
     """
     Read data from databroker and save to Atom class which GUI can take.
 
@@ -807,6 +812,9 @@ def render_data_to_gui(runid):
     ----------
     runid : int
         id number for given run
+    file_overwrite_existing : bool
+        True: overwrite data file if it exists
+        False: create unique file name by adding version number
     """
 
     spectrum_cut = 3000  # Constant: the number of spectrum points to load 3000 ~ 3 keV
@@ -814,10 +822,15 @@ def render_data_to_gui(runid):
     data_sets = OrderedDict()
     img_dict = OrderedDict()
 
+    if file_overwrite_existing:
+        # Don't create unique file name if the existing file is to be overwritten
+        fname_add_version = False
+    else:
+        fname_add_version = True
+
     data_from_db = fetch_data_from_db(runid,
-                                      # Always create unique file name by adding
-                                      #   version number
-                                      fname_add_version=True,
+                                      fname_add_version=fname_add_version,
+                                      file_overwrite_existing=file_overwrite_existing,
                                       # Always load data from all detectors
                                       create_each_det=True,
                                       # Always create data file (processing results

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -822,11 +822,8 @@ def render_data_to_gui(runid, *, file_overwrite_existing=False):
     data_sets = OrderedDict()
     img_dict = OrderedDict()
 
-    if file_overwrite_existing:
-        # Don't create unique file name if the existing file is to be overwritten
-        fname_add_version = False
-    else:
-        fname_add_version = True
+    # Don't create unique file name if the existing file is to be overwritten
+    fname_add_version = not file_overwrite_existing
 
     data_from_db = fetch_data_from_db(runid,
                                       fname_add_version=fname_add_version,

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -451,10 +451,10 @@ class Fit1D(Atom):
             return
 
         # Make sure that the energy of the user peak is within the selected fitting range
-        energy_bound_high = self.param_model.param_new["non_fitting_values"]\
-            ["energy_bound_high"]["value"]
-        energy_bound_low = self.param_model.param_new["non_fitting_values"]\
-            ["energy_bound_low"]["value"]
+        energy_bound_high = \
+            self.param_model.param_new["non_fitting_values"]["energy_bound_high"]["value"]
+        energy_bound_low = \
+            self.param_model.param_new["non_fitting_values"]["energy_bound_low"]["value"]
         self.add_userpeak_energy = np.clip(self.add_userpeak_energy, energy_bound_low, energy_bound_high)
 
         # Ensure, that the values are greater than some small value to ensure that

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -450,15 +450,20 @@ class Fit1D(Atom):
             logger.warning("User peak FWHM must be a positive number.")
             return
 
+        # Make sure that the energy of the user peak is within the selected fitting range
+        energy_bound_high = self.param_model.param_new["non_fitting_values"]\
+            ["energy_bound_high"]["value"]
+        energy_bound_low = self.param_model.param_new["non_fitting_values"]\
+            ["energy_bound_low"]["value"]
+        self.add_userpeak_energy = np.clip(self.add_userpeak_energy, energy_bound_low, energy_bound_high)
+
         # Ensure, that the values are greater than some small value to ensure that
         #   there is no computational problems.
         # Energy resolution for the existing beamlines is 0.01 keV, so 0.001 is small
         #   enough both for center energy and FWHM.
         energy_small_value = 0.001
-        if self.add_userpeak_energy < energy_small_value:
-            self.add_userpeak_energy = energy_small_value
-        if self.add_userpeak_fwhm < energy_small_value:
-            self.add_userpeak_fwhm = energy_small_value
+        self.add_userpeak_energy = max(self.add_userpeak_energy, energy_small_value)
+        self.add_userpeak_fwhm = max(self.add_userpeak_fwhm, energy_small_value)
 
         self._update_userpeak_energy()
         self._update_userpeak_fwhm()

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1664,7 +1664,7 @@ def write_db_to_hdf_base(fpath, data,
         else:
             if file_overwrite_existing:
                 # Overwrite the existing file. This completely deletes the HDF5 file,
-                #   including all information (possibly processing results).
+                #   including all information (possibly processed results).
                 file_open_mode = "w"
             else:
                 raise IOError(f"'write_db_to_hdf_base': File '{fpath}' already exists.")

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1657,16 +1657,15 @@ def write_db_to_hdf_base(fpath, data,
     xrf_det_list.sort()
 
     file_open_mode = "a"
-    if file_overwrite_existing:
-        # Overwrite the existing file. This completely deletes all information in HDF5 file,
-        #   including processing results. The option should be used only if such behavior is
-        #   desired
-        file_open_mode = "w"
-    else:
-        # Creates unique file name or raises an exception
-        if os.path.exists(fpath):
-            if fname_add_version:
-                fpath = _get_fpath_not_existing(fpath)
+    if os.path.exists(fpath):
+        if fname_add_version:
+            # Creates unique file name
+            fpath = _get_fpath_not_existing(fpath)
+        else:
+            if file_overwrite_existing:
+                # Overwrite the existing file. This completely deletes the HDF5 file,
+                #   including all information (possibly processing results).
+                file_open_mode = "w"
             else:
                 raise IOError(f"'write_db_to_hdf_base': File '{fpath}' already exists.")
 

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -88,6 +88,7 @@ def fetch_data_from_db(runid, fpath=None,
                        create_each_det=False,
                        fname_add_version=False,
                        completed_scans_only=False,
+                       file_overwrite_existing=False,
                        output_to_file=False,
                        save_scaler=True,
                        num_end_lines_excluded=None):
@@ -120,6 +121,15 @@ def fetch_data_from_db(runid, fpath=None,
         completed even if not the whole image was scanned. If incomplete scan is
         encountered, an exception is thrown.
         False: the feature is disabled, incomplete scan will be processed.
+    file_overwrite_existing : bool, keyword parameter
+        This option should be used if the existing file should be deleted and replaced
+        with the new file with the same name. This option should be used with caution,
+        since the existing file may contain processed data, which will be permanently deleted.
+        True: overwrite existing files if needed. Note, that if ``fname_add_version`` is ``True``,
+        then new versions of the existing file will always be created.
+        False: do not overwrite existing files. If the file already exists, then the exception
+        will be raised (loading the single scan) or the scan will be skipped (loading the range
+        of scans).
     output_to_file : bool, optional
         save data to hdf5 file if True
     save_scaler : bool, optional
@@ -139,6 +149,7 @@ def fetch_data_from_db(runid, fpath=None,
                               create_each_det=create_each_det,
                               fname_add_version=fname_add_version,
                               completed_scans_only=completed_scans_only,
+                              file_overwrite_existing=file_overwrite_existing,
                               output_to_file=output_to_file)
     elif (hdr.start.beamline_id == 'xf05id' or
           hdr.start.beamline_id == 'SRX'):
@@ -146,6 +157,7 @@ def fetch_data_from_db(runid, fpath=None,
                               create_each_det=create_each_det,
                               fname_add_version=fname_add_version,
                               completed_scans_only=completed_scans_only,
+                              file_overwrite_existing=file_overwrite_existing,
                               output_to_file=output_to_file,
                               save_scaler=save_scaler,
                               num_end_lines_excluded=num_end_lines_excluded)
@@ -154,12 +166,14 @@ def fetch_data_from_db(runid, fpath=None,
                               create_each_det=create_each_det,
                               fname_add_version=fname_add_version,
                               completed_scans_only=completed_scans_only,
+                              file_overwrite_existing=file_overwrite_existing,
                               output_to_file=output_to_file)
     elif hdr.start.beamline_id == 'TES':
         data = map_data2D_tes(runid, fpath,
                               create_each_det=create_each_det,
                               fname_add_version=fname_add_version,
                               completed_scans_only=completed_scans_only,
+                              file_overwrite_existing=file_overwrite_existing,
                               output_to_file=output_to_file)
     else:
         print("Databroker is not setup for this beamline")
@@ -171,6 +185,7 @@ def fetch_data_from_db(runid, fpath=None,
 def make_hdf(start, end=None, *, fname=None,
              fname_add_version=False,
              completed_scans_only=False,
+             file_overwrite_existing=False,
              prefix='scan2D_',
              create_each_det=True, save_scaler=True,
              num_end_lines_excluded=None):
@@ -207,7 +222,8 @@ def make_hdf(start, end=None, *, fname=None,
 
             make_hdf(2342, 2441)
 
-        Non-existing scans in the range or scans causing errors during conversion will be skipped.
+        Scans with IDs in specified range, but not existing in the database, or scans causing errors
+        during conversion will be skipped.
 
     fname : string, optional keyword parameter
         path to save data file when ``end`` is ``None`` (only one scan is processed).
@@ -246,6 +262,15 @@ def make_hdf(start, end=None, *, fname=None,
         Such scripts are currently used at HXN and SRX beamlines of NSLS-II, so this feature
         supports the existing workflows.
         False: the feature is disabled, incomplete scan will be processed.
+    file_overwrite_existing : bool, keyword parameter
+        This option should be used if the existing file should be deleted and replaced
+        with the new file with the same name. This option should be used with caution,
+        since the existing file may contain processed data, which will be permanently deleted.
+        True: overwrite existing files if needed. Note, that if ``fname_add_version`` is ``True``,
+        then new versions of the existing file will always be created.
+        False: do not overwrite existing files. If the file already exists, then the exception
+        will be raised (loading the single scan) or the scan will be skipped (loading the range
+        of scans).
     prefix : str, optional
         prefix name of the created data file. If ``fname`` is not specified, it is generated
         automatically in the form ``<prefix>_<scanID>_<some_additional_data>.h5``
@@ -274,6 +299,7 @@ def make_hdf(start, end=None, *, fname=None,
                            create_each_det=create_each_det,
                            fname_add_version=fname_add_version,
                            completed_scans_only=completed_scans_only,
+                           file_overwrite_existing=file_overwrite_existing,
                            output_to_file=True,
                            save_scaler=save_scaler,
                            num_end_lines_excluded=num_end_lines_excluded)
@@ -289,6 +315,7 @@ def make_hdf(start, end=None, *, fname=None,
                                    create_each_det=create_each_det,
                                    fname_add_version=fname_add_version,
                                    completed_scans_only=completed_scans_only,
+                                   file_overwrite_existing=file_overwrite_existing,
                                    output_to_file=True,
                                    save_scaler=save_scaler,
                                    num_end_lines_excluded=num_end_lines_excluded)
@@ -324,6 +351,7 @@ def map_data2D_hxn(runid, fpath,
                    create_each_det=False,
                    fname_add_version=False,
                    completed_scans_only=False,
+                   file_overwrite_existing=False,
                    output_to_file=True):
     """
     Save the data from databroker to hdf file.
@@ -351,6 +379,14 @@ def map_data2D_hxn(runid, fpath,
         completed even if not the whole image was scanned. If incomplete scan is
         encountered: an exception is thrown.
         False: the feature is disabled, incomplete scan will be processed.
+    file_overwrite_existing : bool, keyword parameter
+        This option should be used if the existing file should be deleted and replaced
+        with the new file with the same name. This option should be used with caution,
+        since the existing file may contain processed data, which will be permanently deleted.
+        True: overwrite existing files if needed. Note, that if ``fname_add_version`` is ``True``,
+        then new versions of the existing file will always be created.
+        False: do not overwrite existing files. If the file already exists, then the exception
+        is raised.
     output_to_file : bool, optional
         save data to hdf5 file if True
     """
@@ -413,6 +449,7 @@ def map_data2D_hxn(runid, fpath,
         print('Saving data to hdf file.')
         fpath = write_db_to_hdf_base(fpath, data_out,
                                      fname_add_version=fname_add_version,
+                                     file_overwrite_existing=file_overwrite_existing,
                                      create_each_det=create_each_det)
 
     detector_name = "xpress3"
@@ -457,6 +494,7 @@ def map_data2D_srx(runid, fpath,
                    create_each_det=False,
                    fname_add_version=False,
                    completed_scans_only=False,
+                   file_overwrite_existing=False,
                    output_to_file=True,
                    save_scaler=True,
                    num_end_lines_excluded=None):
@@ -489,6 +527,14 @@ def map_data2D_srx(runid, fpath,
         completed even if not the whole image was scanned. If incomplete scan is
         encountered: an exception is thrown.
         False: the feature is disabled, incomplete scan will be processed.
+    file_overwrite_existing : bool, keyword parameter
+        This option should be used if the existing file should be deleted and replaced
+        with the new file with the same name. This option should be used with caution,
+        since the existing file may contain processed data, which will be permanently deleted.
+        True: overwrite existing files if needed. Note, that if ``fname_add_version`` is ``True``,
+        then new versions of the existing file will always be created.
+        False: do not overwrite existing files. If the file already exists, then the exception
+        is raised.
     output_to_file : bool, optional
         save data to hdf5 file if True
     save_scaler : bool, optional
@@ -578,6 +624,7 @@ def map_data2D_srx(runid, fpath,
                 fpath_out = write_db_to_hdf_base(
                     fpath_out, data_out,
                     fname_add_version=fname_add_version,
+                    file_overwrite_existing=file_overwrite_existing,
                     create_each_det=create_each_det)
                 d_dict = {"dataset": data_out, "file_name": fpath_out, "detector_name": "xs"}
                 data_output.append(d_dict)
@@ -598,6 +645,7 @@ def map_data2D_srx(runid, fpath,
                 fpath_out = write_db_to_hdf_base(
                     fpath_out, data_out,
                     fname_add_version=fname_add_version,
+                    file_overwrite_existing=file_overwrite_existing,
                     create_each_det=create_each_det)
                 d_dict = {"dataset": data_out, "file_name": fpath_out, "detector_name": "xs"}
                 data_output.append(d_dict)
@@ -863,6 +911,7 @@ def map_data2D_srx(runid, fpath,
                 print(f"Saving data to hdf file #{n_detectors_found}: Detector: {detector_name}.")
                 fpath_out = write_db_to_hdf_base(fpath_out, new_data,
                                                  fname_add_version=fname_add_version,
+                                                 file_overwrite_existing=file_overwrite_existing,
                                                  create_each_det=create_each_det)
 
             # Preparing data for the detector ``detector_name`` for output
@@ -887,6 +936,7 @@ def map_data2D_tes(runid, fpath,
                    create_each_det=False,
                    fname_add_version=False,
                    completed_scans_only=False,
+                   file_overwrite_existing=False,
                    output_to_file=True,
                    save_scaler=True):
     """
@@ -921,6 +971,14 @@ def map_data2D_tes(runid, fpath,
         completed even if not the whole image was scanned. If incomplete scan is
         encountered: an exception is thrown.
         False: the feature is disabled, incomplete scan will be processed.
+    file_overwrite_existing : bool, keyword parameter
+        This option should be used if the existing file should be deleted and replaced
+        with the new file with the same name. This option should be used with caution,
+        since the existing file may contain processed data, which will be permanently deleted.
+        True: overwrite existing files if needed. Note, that if ``fname_add_version`` is ``True``,
+        then new versions of the existing file will always be created.
+        False: do not overwrite existing files. If the file already exists, then the exception
+        is raised.
     output_to_file : bool, optional
         save data to hdf5 file if True
 
@@ -1052,6 +1110,7 @@ def map_data2D_tes(runid, fpath,
         print(f"Saving data to hdf file #{n_detectors_found}: Detector: {detector_name}.")
         write_db_to_hdf_base(fpath_out, new_data,
                              fname_add_version=fname_add_version,
+                             file_overwrite_existing=file_overwrite_existing,
                              create_each_det=create_each_det)
 
     d_dict = {"dataset": new_data, "file_name": fpath_out, "detector_name": detector_name}
@@ -1064,6 +1123,7 @@ def map_data2D_xfm(runid, fpath,
                    create_each_det=False,
                    fname_add_version=False,
                    completed_scans_only=False,
+                   file_overwrite_existing=False,
                    output_to_file=True):
     """
     Transfer the data from databroker into a correct format following the
@@ -1095,6 +1155,14 @@ def map_data2D_xfm(runid, fpath,
         completed even if not the whole image was scanned. If incomplete scan is
         encountered: an exception is thrown.
         False: the feature is disabled, incomplete scan will be processed.
+    file_overwrite_existing : bool, keyword parameter
+        This option should be used if the existing file should be deleted and replaced
+        with the new file with the same name. This option should be used with caution,
+        since the existing file may contain processed data, which will be permanently deleted.
+        True: overwrite existing files if needed. Note, that if ``fname_add_version`` is ``True``,
+        then new versions of the existing file will always be created.
+        False: do not overwrite existing files. If the file already exists, then the exception
+        is raised.
     output_to_file : bool, optional
         save data to hdf5 file if True
 
@@ -1141,6 +1209,7 @@ def map_data2D_xfm(runid, fpath,
             print('Saving data to hdf file.')
             write_db_to_hdf_base(fpath, data_out,
                                  fname_add_version=fname_add_version,
+                                 file_overwrite_existing=file_overwrite_existing,
                                  create_each_det=create_each_det)
 
         detector_name = "xs"
@@ -1553,6 +1622,7 @@ def _get_fpath_not_existing(fpath):
 
 def write_db_to_hdf_base(fpath, data,
                          fname_add_version=False,
+                         file_overwrite_existing=False,
                          create_each_det=True):
     """
     This is the function used to save raw experiment data into HDF5 file.
@@ -1586,13 +1656,21 @@ def write_db_to_hdf_base(fpath, data,
     xrf_det_list = [n for n in data.keys() if 'det' in n and 'sum' not in n]
     xrf_det_list.sort()
 
-    if os.path.exists(fpath):
-        if fname_add_version:
-            fpath = _get_fpath_not_existing(fpath)
-        else:
-            raise IOError(f"'write_db_to_hdf_base': File '{fpath}' already exists.")
+    file_open_mode = "a"
+    if file_overwrite_existing:
+        # Overwrite the existing file. This completely deletes all information in HDF5 file,
+        #   including processing results. The option should be used only if such behavior is
+        #   desired
+        file_open_mode = "w"
+    else:
+        # Creates unique file name or raises an exception
+        if os.path.exists(fpath):
+            if fname_add_version:
+                fpath = _get_fpath_not_existing(fpath)
+            else:
+                raise IOError(f"'write_db_to_hdf_base': File '{fpath}' already exists.")
 
-    with h5py.File(fpath, 'a') as f:
+    with h5py.File(fpath, file_open_mode) as f:
         if create_each_det is True:
             for detname in xrf_det_list:
                 new_data = data[detname]

--- a/pyxrf/view/fileio.enaml
+++ b/pyxrf/view/fileio.enaml
@@ -183,8 +183,9 @@ enamldef FileView(DockItem): file_view:
                         if checked:
                             res = question(
                                 self, "Warning",
-                                "Enabling this option may result in overwriting files that contain processing results.\n"
-                                "Continue?")
+                                "Loading data from the database with this option enabled\n"
+                                "may result in overwriting existing files that contain processing results.\n"
+                                "Do you want to enable this option?")
                             if res.text == "No":
                                 cb_file_overwrite_existing.checked = False
 

--- a/pyxrf/view/fileio.enaml
+++ b/pyxrf/view/fileio.enaml
@@ -10,7 +10,7 @@ from enaml.layout.geometry import Box
 from enaml.stdlib.fields import FloatField
 from enaml.stdlib.fields import IntField as DefaultIntField
 from enaml.stdlib.dialog_buttons import DialogButton
-from enaml.stdlib.message_box import critical
+from enaml.stdlib.message_box import critical, question
 import os
 import numpy as np
 from ..model.fileio import sep_v
@@ -124,7 +124,7 @@ enamldef FileView(DockItem): file_view:
             GroupBox: gb_db:
                 enabled = databroker is not None
                 title = 'Data from database'
-                constraints = [hbox(run_lbl, run_num, load_btn, spacer),]
+                constraints = [hbox(run_lbl, run_num, load_btn, cb_file_overwrite_existing, spacer),]
                 Label: run_lbl:
                     text = 'Scan ID: '
 
@@ -174,6 +174,19 @@ enamldef FileView(DockItem): file_view:
                             io_model.window_title_set_run_id(io_model.runid)
 
                         run_num.value = -1
+
+                CheckBox: cb_file_overwrite_existing:
+                    text = 'Overwrite Existing Files'
+                    checkable = True
+                    checked := io_model.file_overwrite_existing
+                    checked ::
+                        if checked:
+                            res = question(
+                                self, "Warning",
+                                "Enabling this option may result in overwriting files that contain processing results.\n"
+                                "Continue?")
+                            if res.text == "No":
+                                cb_file_overwrite_existing.checked = False
 
             GroupBox: gb_fit:
                 constraints = [hbox(fit_lbl, cb_select, spacer)]

--- a/pyxrf/view/fileio.enaml
+++ b/pyxrf/view/fileio.enaml
@@ -183,9 +183,9 @@ enamldef FileView(DockItem): file_view:
                         if checked:
                             res = question(
                                 self, "Warning",
-                                "Loading data from the database with this option enabled\n"
+                                "Loading data from the database with 'Overwrite Existing Files' option enabled\n"
                                 "may result in overwriting existing files that contain processing results.\n"
-                                "Do you want to enable this option?")
+                                "Are you sure you want to enable this option?")
                             if res.text == "No":
                                 cb_file_overwrite_existing.checked = False
 


### PR DESCRIPTION
Changes:

-- The new optional keyword parameter ``file_existing_overwrite`` is added to the ``make_hdf`` function. If ``file_existing_overwrite`` is ``False`` and file for the scan ID already exists in the working directory, then `` make_hdf`` is raising exception if called for single scan ID or skips the scan if called for a range of scan IDs.  If ``file_existing_overwrite`` is ``True``, then the old file is overwritten with the new one. The overwrite option is disabled by default, because it may cause deletion of processing results. Note, that if the parameter ``fname_add_version`` is true, then new files with unique file names will be always created. (The feature was requested by SRX staff). 

- As a GUI extention of the new ``make_hdf`` feature, the ``Overwrite Existing Files`` checkbox is added to the ``Fit`` tab. If the checkbox is checked, then the existing files are overwritten when data is loaded from the databoase. If it is unchecked, then new files with unique file names are created. 