### PR TITLE
Fixes for three minor PyXRF GUI issues

### DIFF
--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -1677,27 +1677,6 @@ def create_movie(data, fname='demo.mp4', dpi=100, cmap='jet',
     ani.save(fname, writer=writer, dpi=dpi)
 
 
-def print_image(fig):
-    """
-    Print function used at beamline only.
-    """
-    if db is not None:
-        hdr = db[-1]
-        if hdr.start.beamline_id == 'HXN':
-            current_dir = os.path.dirname(os.path.realpath(__file__))
-            config_file = 'hxn_pv_config.json'
-            config_path = sep_v.join(current_dir.split(sep_v)[:-2]+['configs', config_file])
-            with open(config_path, 'r') as json_data:
-                config_data = json.load(json_data)
-            fpath = config_data.get('print_path', None)
-            if fpath is None:
-                fpath = '/home/xf03id/Desktop/temp.png'
-            fig.savefig(fpath,  bbox_inches='tight', pad_inches=4)
-            os.system(config_data['print_command'])
-        else:
-            print('Printer is not set up yet.')
-
-
 def spec_to_hdf(wd, spec_file, spectrum_file, output_file, img_shape,
                 ic_name=None, x_name=None, y_name=None):
     """

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -1072,6 +1072,9 @@ enamldef ElementEdit(Window):
     attr param_model
     attr plot_model
     attr setting_model
+
+    title = "Edit Fitting Parameters for Selected Emission Lines"
+
     Container:
         constraints = [vbox(hbox(cal_pbn, spacer),
                             cmb_element,
@@ -1080,7 +1083,7 @@ enamldef ElementEdit(Window):
         padding = Box(5, 5, 5, 5)
 
         PushButton: cal_pbn:
-            text = 'Update & Plot'
+            text = 'Update and Plot'
             clicked ::
                 calculate_spectrum_helper(fit_model, plot_model,
                                           param_model, setting_model)

--- a/pyxrf/view/image2D.enaml
+++ b/pyxrf/view/image2D.enaml
@@ -33,7 +33,8 @@ enamldef ImageMain(DockItem):
     Container:
         constraints = [
             vbox(
-                hbox(cbox_file, spacer, pb_all, interpolate_cb, scatter_cb, pb_print),
+                hbox(cbox_file, spacer, pb_all, interpolate_cb, scatter_cb),
+                #hbox(cbox_file, spacer, pb_all, interpolate_cb, scatter_cb, pb_print),
                 hbox(spacer, cb_select, color_select, cb_norm, pixel_select, tb_check),
                 canvas,
             ),
@@ -91,10 +92,11 @@ enamldef ImageMain(DockItem):
             text = 'Toolbar Visible'
             checked := canvas.toolbar_visible
 
-        PushButton: pb_print:
-            text  ='Print'
-            clicked ::
-                print_image(img_model_adv.fig)
+#        PushButton: pb_print:
+#            text  ='Print'
+#            clicked ::
+#                print_image(img_model_adv.fig)
+
         MPLCanvas: canvas:
             toolbar_visible = True
             figure << choose_element.img_model.fig

--- a/pyxrf/view/image2D.enaml
+++ b/pyxrf/view/image2D.enaml
@@ -16,8 +16,6 @@ import six
 import numpy as np
 from matplotlib.figure import Figure
 
-from pyxrf.model.fileio import print_image
-
 import logging
 logger = logging.getLogger()
 
@@ -34,7 +32,6 @@ enamldef ImageMain(DockItem):
         constraints = [
             vbox(
                 hbox(cbox_file, spacer, pb_all, interpolate_cb, scatter_cb),
-                #hbox(cbox_file, spacer, pb_all, interpolate_cb, scatter_cb, pb_print),
                 hbox(spacer, cb_select, color_select, cb_norm, pixel_select, tb_check),
                 canvas,
             ),
@@ -91,11 +88,6 @@ enamldef ImageMain(DockItem):
         CheckBox: tb_check:
             text = 'Toolbar Visible'
             checked := canvas.toolbar_visible
-
-#        PushButton: pb_print:
-#            text  ='Print'
-#            clicked ::
-#                print_image(img_model_adv.fig)
 
         MPLCanvas: canvas:
             toolbar_visible = True

--- a/pyxrf/view/image2D.enaml
+++ b/pyxrf/view/image2D.enaml
@@ -10,6 +10,8 @@ from enaml.core.api import Include, Looper
 
 from enaml.stdlib.fields import FloatField as DefaultFloatField
 
+from enaml.validator import FloatValidator
+
 import six
 import numpy as np
 from matplotlib.figure import Figure
@@ -168,12 +170,41 @@ enamldef ChooseElementAdvanced(Window): win:
                                     maximum = 100
                                     low_value >> img_model.limit_dict[loop_item]['low']
                                     high_value >> img_model.limit_dict[loop_item]['high']
+                                    high_value ::
+                                        lw = img_model.range_dict[loop_item]['low']
+                                        hg = img_model.range_dict[loop_item]['high']
+                                        ff_high.text = img_model.format_img_wizard_limit(lw + (hg - lw) * high_value / 100.0)
+
+                                    low_value ::
+                                        lw = img_model.range_dict[loop_item]['low']
+                                        hg = img_model.range_dict[loop_item]['high']
+                                        ff_low.text = img_model.format_img_wizard_limit(lw + (hg - lw) * low_value / 100.0)
                                 Field: ff_low:
-                                    read_only = True
                                     text << img_model.format_img_wizard_limit(img_model.range_dict[loop_item]['low'])
+                                    validator = FloatValidator(minimum=img_model.range_dict[loop_item]['low'],
+                                                               maximum=img_model.range_dict[loop_item]['high'])
+                                    text ::
+                                        val = float(text)  # Validator guarantees that the text can be parsed to float
+                                        lw = img_model.range_dict[loop_item]['low']
+                                        hg = img_model.range_dict[loop_item]['high']
+                                        val = np.clip(val, a_min=lw, a_max=hg)
+                                        s_val = (val - lw) / (hg - lw) * 100
+                                        dual_slider.low_value = int(round(s_val))
+                                        img_model.limit_dict[loop_item]['low'] = s_val
+                                        # Note: the text field is not getting updated, so it remains correct
                                 Field: ff_high:
-                                    read_only = True
                                     text << img_model.format_img_wizard_limit(img_model.range_dict[loop_item]['high'])
+                                    validator = FloatValidator(minimum=img_model.range_dict[loop_item]['low'],
+                                                               maximum=img_model.range_dict[loop_item]['high'])
+                                    text ::
+                                        val = float(text)  # Validator guarantees that the text can be parsed to float
+                                        lw = img_model.range_dict[loop_item]['low']
+                                        hg = img_model.range_dict[loop_item]['high']
+                                        val = np.clip(val, a_min=lw, a_max=hg)
+                                        s_val = (val - lw) / (hg - lw) * 100
+                                        dual_slider.high_value = int(round(s_val))
+                                        img_model.limit_dict[loop_item]['high'] = s_val
+                                        # Note: the text field is not getting updated, so it remains correct
                                 PushButton: reset_btn:
                                     text = 'Reset'
                                     clicked ::

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -49,7 +49,8 @@ enamldef PlotMain(DockItem):
     Container:
         constraints = [
             vbox(
-                hbox(plot_exp_btn, pb_plot_fit, spacer, pb_print),
+                hbox(plot_exp_btn, pb_plot_fit, spacer),
+                #hbox(plot_exp_btn, pb_plot_fit, spacer, pb_print),
                 #hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, cbox2, btn_cb_prev, btn_cb_next, checkb),
                 hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, eline_selection, checkb),
                 canvas,
@@ -131,10 +132,10 @@ enamldef PlotMain(DockItem):
                         cbox2.index += 1
                     cbox2.set_focus()  # Return focus to the combo box
 
-        PushButton: pb_print:
-            text  ='Print'
-            clicked ::
-                print_image(plot_model._fig)
+        #PushButton: pb_print:
+        #    text  ='Print'
+        #    clicked ::
+        #        print_image(plot_model._fig)
 
         PushButton: plot_exp_btn:
             text = 'Plot Selected Exp. Data'

--- a/pyxrf/view/lineplot.enaml
+++ b/pyxrf/view/lineplot.enaml
@@ -8,7 +8,6 @@ from enaml.layout.api import hbox, vbox, HSplitLayout, VSplitLayout, spacer
 from enaml.stdlib.fields import FloatField as DefaultFloatField
 from atom.api import *
 from ..model.lineplot import LinePlotModel
-from pyxrf.model.fileio import print_image
 
 from enaml.stdlib.dialog_buttons import DialogButton
 from enaml.stdlib.message_box import critical
@@ -50,7 +49,6 @@ enamldef PlotMain(DockItem):
         constraints = [
             vbox(
                 hbox(plot_exp_btn, pb_plot_fit, spacer),
-                #hbox(plot_exp_btn, pb_plot_fit, spacer, pb_print),
                 #hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, cbox2, btn_cb_prev, btn_cb_next, checkb),
                 hbox(cbox1, spacer, pb_eline, add_eline, remove_eline, eline_selection, checkb),
                 canvas,
@@ -131,11 +129,6 @@ enamldef PlotMain(DockItem):
                     if cbox2.index < len(cbox2.items) - 1:
                         cbox2.index += 1
                     cbox2.set_focus()  # Return focus to the combo box
-
-        #PushButton: pb_print:
-        #    text  ='Print'
-        #    clicked ::
-        #        print_image(plot_model._fig)
 
         PushButton: plot_exp_btn:
             text = 'Plot Selected Exp. Data'

--- a/pyxrf/view/rgb_image.enaml
+++ b/pyxrf/view/rgb_image.enaml
@@ -14,11 +14,8 @@ import six
 import numpy as np
 from matplotlib.figure import Figure
 
-from pyxrf.model.fileio import print_image
-
 import logging
 logger = logging.getLogger()
-
 
 enamldef RadioButton(DefaultRadioButton):
     minimum_size = (5, 26)
@@ -64,11 +61,6 @@ enamldef ImageRGB(DockItem):
             text = 'Update Plot'
             clicked ::
                 img_model_adv.show_image()
-
-        #PushButton: pb_print:
-        #    text  ='Print'
-        #    clicked ::
-        #        print_image(img_model_adv.fig)
 
         CheckBox: tb_check:
             text = 'Toolbar Visible'

--- a/pyxrf/view/rgb_image.enaml
+++ b/pyxrf/view/rgb_image.enaml
@@ -32,7 +32,8 @@ enamldef ImageRGB(DockItem):
         constraints = [
         vbox(
             #hbox(pb_all, spacer),
-            hbox(cbox_file, cb_norm, pixel_select, interpolate_cb, spacer, pb_print),
+            hbox(cbox_file, spacer, cb_norm, pixel_select, interpolate_cb),
+            #hbox(cbox_file, cb_norm, pixel_select, interpolate_cb, spacer, pb_print),
             hbox(plot_btn, spacer, tb_check),
             #hbox(spacer, cb_select, cb_norm, tb_check),
             hbox(vbox(lb_select, sa_elements), vbox(canvas, ct_rgb),),
@@ -64,10 +65,10 @@ enamldef ImageRGB(DockItem):
             clicked ::
                 img_model_adv.show_image()
 
-        PushButton: pb_print:
-            text  ='Print'
-            clicked ::
-                print_image(img_model_adv.fig)
+        #PushButton: pb_print:
+        #    text  ='Print'
+        #    clicked ::
+        #        print_image(img_model_adv.fig)
 
         CheckBox: tb_check:
             text = 'Toolbar Visible'


### PR DESCRIPTION
Two small changes:

-- ``Element Map`` tab -> Image Wizard: the range of displayed values may now be changed by moving sliders or by typing in the text fields. Sliders and text fields for each element line are now linked, so changes in one control are reflected in the state of the other control.

-- ``Fit`` tab -> Edit Element: set the window title. The ``Edit Element`` window was displayed with empty header, now it displays the title ``Edit Fitting Parameters for Selected Emission Lines``.

-- Removed unused ``Print`` button in 3 data plotting tabs. The button was crashing the program.