### PR TITLE
Optimization of memory use

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+# show coverage in CI status, not as a comment.
+comment: off
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,4 +81,4 @@ script:
   fi
 
 after_success:
-  - if [ $SUBMIT_CODECOV == 'true' ]; then codecov; fi;
+  #- if [ $SUBMIT_CODECOV == 'true' ]; then codecov; fi;

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -270,7 +270,9 @@ class FileIOModel(Atom):
         #                                             self.fname_from_db,
         #                                             load_each_channel=self.load_each_channel)
 
-        rv = render_data_to_gui(self.runid, file_overwrite_existing=self.file_overwrite_existing)
+        rv = render_data_to_gui(self.runid,
+                                create_each_det=self.load_each_channel,
+                                file_overwrite_existing=self.file_overwrite_existing)
 
         if rv is None:
             logger.error(f"Data from scan #{self.runid} was not loaded")
@@ -1008,7 +1010,7 @@ def read_hdf_APS(working_directory,
     return img_dict, data_sets, mdata
 
 
-def render_data_to_gui(runid, *, file_overwrite_existing=False):
+def render_data_to_gui(runid, *, create_each_det=False, file_overwrite_existing=False):
     """
     Read data from databroker and save to Atom class which GUI can take.
 
@@ -1018,6 +1020,9 @@ def render_data_to_gui(runid, *, file_overwrite_existing=False):
     ----------
     runid : int
         id number for given run
+    create_each_det : bool
+        True: load data from all detector channels
+        False: load only the sum of all channels
     file_overwrite_existing : bool
         True: overwrite data file if it exists
         False: create unique file name by adding version number
@@ -1034,8 +1039,7 @@ def render_data_to_gui(runid, *, file_overwrite_existing=False):
     data_from_db = fetch_data_from_db(runid,
                                       fname_add_version=fname_add_version,
                                       file_overwrite_existing=file_overwrite_existing,
-                                      # Always load data from all detectors
-                                      create_each_det=True,
+                                      create_each_det=create_each_det,
                                       # Always create data file (processing results
                                       #   are going to be saved in the file)
                                       output_to_file=True)

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -462,7 +462,7 @@ class DataSelection(Atom):
                                     pos2=self.point2)
             spec = SC.get_spectrum()
         # Return the 'sum' spectrum as regular 64-bit float (raw data is in 'np.float32')
-        return np.float64(spec)
+        return spec.astype(np.float64, copy=False)
 
 
 class SpectrumCalculator(object):

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -920,6 +920,7 @@ class Fit1D(Atom):
                     f"{self.param_dict['coherent_sct_energy']['value']} keV) --------")
         t0 = time.time()
         self.pixel_fit_info = 'Pixel fitting is in process.'
+
         # app.processEvents()
         self.result_map, calculation_info = single_pixel_fitting_controller(
             self.data_all,

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1416,6 +1416,7 @@ def map_data2D_xfm(runid, fpath,
                               datashape,
                               det_list=xrf_detector_names,
                               pos_list=hdr.start.motors,
+                              create_each_det=create_each_det,
                               scaler_list=config_data['scaler_list'],
                               fly_type=fly_type)
         if output_to_file:

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1873,6 +1873,23 @@ def write_db_to_hdf_base(fpath, data, *, metadata=None,
     xrf_det_list = [n for n in data.keys() if 'det' in n and 'sum' not in n]
     xrf_det_list.sort()
 
+    # Verify that raw fluorescence data is represented with np.float32 precision: print the warning message
+    #   and convert the raw spectrum data to np.float32. Assume that data is represented as ndarray.
+    def incorrect_type_msg(channel, data_type):
+        logger.warning(f"Attemptying to save raw fluorescence data for the channel '{channel}' "
+                       f"as '{data_type}' numbers.\n    Memory may not be used efficiently. "
+                       f"Please, inform the PyXRF developers.\n    The data is converted from '{data_type}' "
+                       f"to 'np.float32' before saving to file.")
+    if "det_sum" in data and isinstance(data["det_sum"], np.ndarray):
+        if data["det_sum"].dtype != np.float32:
+            incorrect_type_msg("det_sum", data["det_sum"].dtype)
+            data["det_sum"] = np.float32(data["det_sum"])
+    for detname in xrf_det_list:
+        if detname in data and isinstance(data[detname], np.ndarray):
+            if data[detname].dtype != np.float32:
+                incorrect_type_msg(detname, data[detname].dtype)
+                data[detname] = np.float32(data[detname])
+
     file_open_mode = "a"
     if os.path.exists(fpath):
         if fname_add_version:

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1629,7 +1629,7 @@ def assemble_data_SRX_stepscan(
             new_v_shape = len(channel_data) // datashape[1]
 
             new_data = np.vstack(channel_data)
-            new_data = np.float32(new_data)  # Change representation to np.float32
+            new_data = new_data.astype(np.float32, copy=False)  # Change representation to np.float32
             new_data = new_data[:new_v_shape*datashape[1], :]
 
             new_data = new_data.reshape([new_v_shape, datashape[1],
@@ -1767,7 +1767,7 @@ def map_data2D(data, datashape,
             # new veritcal shape is defined to ignore zeros points caused by stopped/aborted scans
             new_v_shape = len(channel_data) // datashape[1]
             new_data = np.vstack(channel_data)
-            new_data = np.float32(new_data)  # Convert to np.float32 representation
+            new_data = new_data.astype(np.float32, copy=False)  # Change representation to np.float32
             new_data = new_data[:new_v_shape*datashape[1], :]
             new_data = new_data.reshape([new_v_shape, datashape[1],
                                          len(channel_data[1])])
@@ -1898,12 +1898,12 @@ def write_db_to_hdf_base(fpath, data, *, metadata=None,
     if "det_sum" in data and isinstance(data["det_sum"], np.ndarray):
         if data["det_sum"].dtype != np.float32:
             incorrect_type_msg("det_sum", data["det_sum"].dtype)
-            data["det_sum"] = np.float32(data["det_sum"])
+            data["det_sum"] = data["det_sum"].astype(np.float32, copy=False)
     for detname in xrf_det_list:
         if detname in data and isinstance(data[detname], np.ndarray):
             if data[detname].dtype != np.float32:
                 incorrect_type_msg(detname, data[detname].dtype)
-                data[detname] = np.float32(data[detname])
+                data[detname] = data[detname].astype(np.float32, copy=False)
 
     file_open_mode = "a"
     if os.path.exists(fpath):

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -740,10 +740,21 @@ def map_data2D_srx(runid, fpath,
         fly_type = None
 
         if num_end_lines_excluded is None:
-            # vertical first then horizontal, assuming fast scan on x
-            datashape = [start_doc['shape'][1], start_doc['shape'][0]]
+            # It seems like the 'shape' in plan is in the form of [y, x], where
+            #    y - is the vertical and x is horizontal axis. This matches the
+            #    shape of the matrix that is used for storage of the maps.
+            #    In step scan, the results are represented as 1D array, not 2D array,
+            #    so it needs to be reshaped before processing. So the datashape
+            #    needs to be determined correctly.
+            # We also assume that scanning is performed along the x-axis first
+            #    before stepping along y-axis. Snaking may be on or off.
+            #    Different order (along y-axis first, then along x-axis) will require
+            #    some additional parameter in the start document to indicate this.
+            #    And the 'datashape' will need to be set the opposite way. Also
+            #    the map representation will be transposed.
+            datashape = [start_doc['shape'][0], start_doc['shape'][1]]
         else:
-            datashape = [start_doc['shape'][1] - num_end_lines_excluded, start_doc['shape'][0]]
+            datashape = [start_doc['shape'][0] - num_end_lines_excluded, start_doc['shape'][1]]
 
         snake_scan = start_doc.get('snaking')
         if snake_scan[1] is True:

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -344,6 +344,11 @@ class SettingModel(Atom):
         data_raw = np.asarray(datav.raw_data)
 
         if self.subtract_background:
+            # TODO: Implementation of background subtraction is not memory efficient
+            #   and may cause problems when processing large scans. Eventually it
+            #   needs to be rewritten, so that the data is processed in batches and
+            #   no complete copy of raw data is created in memory. This does not affect
+            #   computation of ROI without background subtraction (which is typical).
 
             logger.info(f"Subtracting background ...")
 
@@ -381,6 +386,7 @@ class SettingModel(Atom):
                                   e_offset=self.parameters['e_offset']['value'],
                                   e_linear=self.parameters['e_linear']['value'],
                                   range_v=[leftv, rightv])
+            sum2D = sum2D.astype(np.float64, copy=False)  # Convert to 64-bit representation
             temp.update({k: sum2D})
             logger.debug(f"Calculation is completed for {v.prefix}, {self.data_title}, {k}")
 

--- a/pyxrf/simulation/sim_xrf_scan_data.py
+++ b/pyxrf/simulation/sim_xrf_scan_data.py
@@ -216,8 +216,9 @@ def gen_xrf_map_const(element_line_groups=None, *,
     Returns
     -------
 
-    xrf_map: ndarray(float)
+    xrf_map: ndarray(np.float32)
         XRF map with the shape ``(ny, nx, n_spectrum_points)``.
+        Raw XRF spectra are represented with 32-bit precision.
 
     xx_energy: ndarray(float)
         The values for the energy axis. Size: 'n_spectrum_points'.
@@ -244,6 +245,9 @@ def gen_xrf_map_const(element_line_groups=None, *,
 
     background = background_area / spectrum.size
     spectrum += background
+
+    # One spectrum is computed. Now change precision to 32 bit before using it to create a map
+    spectrum = np.float32(spectrum)
 
     xrf_map = np.broadcast_to(spectrum, shape=[ny, nx, len(spectrum)])
 
@@ -364,9 +368,9 @@ def create_xrf_map_data(*, scan_id,
 
     # Create datasets
     data_xrf = {}
-    data_xrf["det_sum"] = np.copy(xrf_map)
+    data_xrf["det_sum"] = xrf_map  # 'xrf_map' is np.float32
     for n in range(num_det_channels):
-        data_xrf[f"det{n + 1}"] = xrf_map * channel_coef[n]
+        data_xrf[f"det{n + 1}"] = xrf_map * channel_coef[n]  # The arrays remain np.float32
 
     data_scalers = {}
     scaler_names = ["i0", "time", "time_diff"]

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -1037,6 +1037,12 @@ enamldef FitView(DockItem): fit_view:
                                 btns = [DialogButton('Ok', 'accept')]
                                 critical(self, 'ERROR', f'Failed to save quantitative calibration: {ex}', btns)
 
+                        # If the checkbox is set True in 'save_quant_calibration_edit', reset it to False
+                        #   This checkbox is a safety feature, and should be checked each time the
+                        #   Dialog Box is opened (for each new file, or each attempt to save the same file)
+                        fit_model.qe_standard_overwrite_existing = False
+
+
             PushButton: to_db:
                 text = 'Save to DB'
                 enabled = False  # Disable this button (database for processing data does not exist yet)

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -31,6 +31,9 @@ from ..model.fileio import sep_v
 from skbeam.core.fitting.xrf_model import (K_LINE, L_LINE, M_LINE)
 from skbeam.fluorescence import XrfElement as Element
 
+import logging
+logger = logging.getLogger()
+
 try:
     import databroker
 except ImportError:


### PR DESCRIPTION
More efficient memory use by PyXRF:

-- Change the default options for loading data from databroker using GUI and 'make_hdf': only the sum of all channels are loaded from databroker and saved to local .h5 file.

-- Loading of all channels may be enabled by setting 'make_hdf' parameter 'create_each_det=True' or checking 'Load all channels' checkbox in GUI.

-- Raw spectral data for XRF maps are now stored in .h5 files and memory as np.float32 (instead of np.float64). The data is still converted to np.float64 before computations.

Additional minor change: the checkbox 'Overwrite existing file' in Dialog 'Save quantitative calibration' in the is unchecked after saving the file (as a safety feature, the checkbox must be checked each time the file needs to be overwritten).