### PR TITLE
Updated installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,7 +48,7 @@ identical for all supported OS.
 
    .. code:: python
 
-       conda install pyxrf -c nsls2forge
+       conda install pyxrf scikit-beam -c nsls2forge
 
 
 Starting PyXRF
@@ -88,7 +88,7 @@ Updating PyXRF
 
    .. code:: python
 
-       conda update pyxrf -c nsls2forge
+       conda update pyxrf scikit-beam -c nsls2forge
 
 
 Deactivating Conda environment


### PR DESCRIPTION
Updated instructions for installation of PyXRF on user PCs. Scikit-beam should also be updated when the new version becomes available. Scikit-beam is not listed as dependency for PyXRF for smoother develop installation of the beamlines.