### PR TITLE
Fixed multiple bugs

### DIFF
--- a/pyxrf/core/quant_analysis.py
+++ b/pyxrf/core/quant_analysis.py
@@ -547,12 +547,14 @@ def fill_quant_fluor_data_dict(quant_fluor_data_dict, *, xrf_map_dict, scaler_na
             # Ignore pixels along the edges (those pixels are likely to be outliers that will visibly bias
             #   the mean value in small calibration scans). If scan is smaller that 2 pixels along any
             #   dimension, then all pixels are used, including edges.
+
             def _get_range(n_elements):
                 if n_elements > 2:
                     n_min, n_max = 1, n_elements - 1
                 else:
                     n_min, n_max = 0, n_elements
                 return n_min, n_max
+
             ny_min, ny_max = _get_range(norm_map.shape[0])
             nx_min, nx_max = _get_range(norm_map.shape[1])
             mean_fluor = np.mean(norm_map[ny_min: ny_max, nx_min: nx_max])

--- a/pyxrf/core/quant_analysis.py
+++ b/pyxrf/core/quant_analysis.py
@@ -494,6 +494,11 @@ def fill_quant_fluor_data_dict(quant_fluor_data_dict, *, xrf_map_dict, scaler_na
     ``scaler_name`` is not one of the keys of ``xrf_map_dict`` or set to None, then
     the average fluorescence is computed without normalization.
 
+    Pixels along the edges of the map are very likely to contain outliers, so the edges
+    are not used in computation whenever sufficient data is available (if map contains
+    more than 2 pixels along a dimension, the the first and the last pixel not used
+    for averaging)
+
     Parameters
     ----------
 

--- a/pyxrf/core/quant_analysis.py
+++ b/pyxrf/core/quant_analysis.py
@@ -496,7 +496,7 @@ def fill_quant_fluor_data_dict(quant_fluor_data_dict, *, xrf_map_dict, scaler_na
 
     Pixels along the edges of the map are very likely to contain outliers, so the edges
     are not used in computation whenever sufficient data is available (if map contains
-    more than 2 pixels along a dimension, the the first and the last pixel not used
+    more than 2 pixels along a dimension, the first and the last pixels are not used
     for averaging)
 
     Parameters

--- a/pyxrf/core/quant_analysis.py
+++ b/pyxrf/core/quant_analysis.py
@@ -539,7 +539,18 @@ def fill_quant_fluor_data_dict(quant_fluor_data_dict, *, xrf_map_dict, scaler_na
                 norm_map = normalize_data_by_scaler(xrf_map_dict[eline], xrf_map_dict[scaler_name])
             else:
                 norm_map = xrf_map_dict[eline]
-            mean_fluor = np.mean(norm_map)
+            # Ignore pixels along the edges (those pixels are likely to be outliers that will visibly bias
+            #   the mean value in small calibration scans). If scan is smaller that 2 pixels along any
+            #   dimension, then all pixels are used, including edges.
+            def _get_range(n_elements):
+                if n_elements > 2:
+                    n_min, n_max = 1, n_elements - 1
+                else:
+                    n_min, n_max = 0, n_elements
+                return n_min, n_max
+            ny_min, ny_max = _get_range(norm_map.shape[0])
+            nx_min, nx_max = _get_range(norm_map.shape[1])
+            mean_fluor = np.mean(norm_map[ny_min: ny_max, nx_min: nx_max])
             # Note: numpy 'float64' is explicitely converted to 'float'
             #     (yaml package does not seem to support 'float64')
             quant_fluor_data_dict["element_lines"][eline]["fluorescence"] = float(mean_fluor)

--- a/pyxrf/core/tests/test_quant_analysis.py
+++ b/pyxrf/core/tests/test_quant_analysis.py
@@ -365,6 +365,7 @@ def gen_xrf_map_dict(nx=10, ny=5, elines=["S_K", "Au_M", "Fe_K"]):
 
     return img
 
+
 @pytest.mark.parametrize("map_dims", [
     {"nx": 10, "ny": 5},
     {"nx": 1, "ny": 5},

--- a/pyxrf/core/tests/test_quant_analysis.py
+++ b/pyxrf/core/tests/test_quant_analysis.py
@@ -365,16 +365,38 @@ def gen_xrf_map_dict(nx=10, ny=5, elines=["S_K", "Au_M", "Fe_K"]):
 
     return img
 
-
-def test_fill_quant_fluor_data_dict():
+@pytest.mark.parametrize("map_dims", [
+    {"nx": 10, "ny": 5},
+    {"nx": 1, "ny": 5},
+    {"nx": 2, "ny": 5},
+    {"nx": 3, "ny": 5},
+    {"nx": 10, "ny": 1},
+    {"nx": 10, "ny": 2},
+    {"nx": 10, "ny": 3},
+])
+def test_fill_quant_fluor_data_dict(map_dims):
     r"""Test for 'fill_quant_fluor_data_dict': testing basic functionality"""
     # Create copy, because the dictionary will be modified
     fluor_standard = copy.deepcopy(_xrf_standard_fluor_sample)
 
-    img = gen_xrf_map_dict()
-    map_S_K_fluor = np.mean(img["S_K"])
-    map_Au_M_fluor = np.mean(img["Au_M"])
-    v_sclr = np.mean(img["sclr"])
+    nx = map_dims["nx"]
+    ny = map_dims["ny"]
+
+    img = gen_xrf_map_dict(nx=nx, ny=ny)
+
+    if nx < 3:
+        nx_min, nx_max = 0, nx
+    else:
+        nx_min, nx_max = 1, -1
+
+    if ny < 3:
+        ny_min, ny_max = 0, nx
+    else:
+        ny_min, ny_max = 1, -1
+
+    map_S_K_fluor = np.mean(img["S_K"][ny_min: ny_max, nx_min: nx_max])
+    map_Au_M_fluor = np.mean(img["Au_M"][ny_min: ny_max, nx_min: nx_max])
+    v_sclr = np.mean(img["sclr"][ny_min: ny_max, nx_min: nx_max])
 
     # Fill the dictionary, use existing scaler 'sclr'
     fill_quant_fluor_data_dict(fluor_standard, xrf_map_dict=img, scaler_name="sclr")

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -1046,6 +1046,8 @@ def render_data_to_gui(runid, *, create_each_det=False, working_directory=None, 
     if working_directory:
         fname = os.path.join(working_directory, fname)
 
+    print(f"File name: {fname}")
+
     data_from_db = fetch_data_from_db(runid,
                                       fpath=fname,
                                       fname_add_version=fname_add_version,

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -270,7 +270,6 @@ class FileIOModel(Atom):
         #                                             self.fname_from_db,
         #                                             load_each_channel=self.load_each_channel)
 
-        print(f"Working directory: {self.working_directory}") ##!!
         rv = render_data_to_gui(self.runid,
                                 create_each_det=self.load_each_channel,
                                 working_directory=self.working_directory,
@@ -1045,8 +1044,6 @@ def render_data_to_gui(runid, *, create_each_det=False, working_directory=None, 
     fname = f"{prefix}{runid}.h5"
     if working_directory:
         fname = os.path.join(working_directory, fname)
-
-    print(f"File name: {fname}")
 
     data_from_db = fetch_data_from_db(runid,
                                       fpath=fname,

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -270,6 +270,7 @@ class FileIOModel(Atom):
         #                                             self.fname_from_db,
         #                                             load_each_channel=self.load_each_channel)
 
+        print(f"Working directory: {self.working_directory}") ##!!
         rv = render_data_to_gui(self.runid,
                                 create_each_det=self.load_each_channel,
                                 working_directory=self.working_directory,
@@ -1039,8 +1040,14 @@ def render_data_to_gui(runid, *, create_each_det=False, working_directory=None, 
     # Don't create unique file name if the existing file is to be overwritten
     fname_add_version = not file_overwrite_existing
 
+    # Create file name here, so that working directory may be attached to the file name
+    prefix = 'scan2D_'
+    fname = f"{prefix}{runid}.h5"
+    if working_directory:
+        fname = os.path.join(working_directory, fname)
+
     data_from_db = fetch_data_from_db(runid,
-                                      fpath=working_directory,
+                                      fpath=fname,
                                       fname_add_version=fname_add_version,
                                       file_overwrite_existing=file_overwrite_existing,
                                       create_each_det=create_each_det,

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -272,6 +272,7 @@ class FileIOModel(Atom):
 
         rv = render_data_to_gui(self.runid,
                                 create_each_det=self.load_each_channel,
+                                working_directory=self.working_directory,
                                 file_overwrite_existing=self.file_overwrite_existing)
 
         if rv is None:
@@ -1010,7 +1011,7 @@ def read_hdf_APS(working_directory,
     return img_dict, data_sets, mdata
 
 
-def render_data_to_gui(runid, *, create_each_det=False, file_overwrite_existing=False):
+def render_data_to_gui(runid, *, create_each_det=False, working_directory=None, file_overwrite_existing=False):
     """
     Read data from databroker and save to Atom class which GUI can take.
 
@@ -1023,6 +1024,8 @@ def render_data_to_gui(runid, *, create_each_det=False, file_overwrite_existing=
     create_each_det : bool
         True: load data from all detector channels
         False: load only the sum of all channels
+    working_directory : str
+        path to the directory where data files are saved
     file_overwrite_existing : bool
         True: overwrite data file if it exists
         False: create unique file name by adding version number
@@ -1037,6 +1040,7 @@ def render_data_to_gui(runid, *, create_each_det=False, file_overwrite_existing=
     fname_add_version = not file_overwrite_existing
 
     data_from_db = fetch_data_from_db(runid,
+                                      fpath=working_directory,
                                       fname_add_version=fname_add_version,
                                       file_overwrite_existing=file_overwrite_existing,
                                       create_each_det=create_each_det,

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -376,6 +376,7 @@ class Fit1D(Atom):
             d = None
         if d <= 0.0:
             d = None
+        self.param_quant_estimation.set_distance_to_sample_in_data_dict(distance_to_sample=d)
         # Change preview if distance value changed
         self.qe_standard_data_preview = \
             self.param_quant_estimation.get_fluorescence_data_dict_text_preview()
@@ -386,7 +387,7 @@ class Fit1D(Atom):
             d = float(self.qe_standard_distance)
         except Exception:
             d = None
-        if d <= 0.0:
+        if (d is not None) and (d <= 0.0):
             d = None
         return d
 

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -27,8 +27,7 @@ bound_options = ['none', 'lohi', 'fixed', 'lo', 'hi']
 fit_strategy_list = ['fit_with_tail', 'free_more',
                      'e_calibration', 'linear',
                      'adjust_element1', 'adjust_element2', 'adjust_element3']
-autofit_param = ['e_offset', 'e_linear', 'fwhm_offset', 'fwhm_fanoprime',
-                 'coherent_sct_energy']
+autofit_param = ['e_offset', 'e_linear', 'fwhm_offset', 'fwhm_fanoprime']
 
 
 class PreFitStatus(Atom):

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -1300,9 +1300,6 @@ enamldef AutoFindElements(Window): auto_win:
                     constraints = [hbox(ff, pb_value_default)]
                     FloatField: ff:
                         value := param_model.param_new[loop_item]['value']
-                        value ::
-                            if loop_item == 'coherent_sct_energy':
-                                io_model.incident_energy_set = value
                         maximum_size = 160
                     PushButton: pb_value_default:
                         text = 'Default'

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -1310,6 +1310,25 @@ enamldef AutoFindElements(Window): auto_win:
                         clicked ::
                             ff.value = param_model.param_new[loop_item]['default']
 
+            Looper:
+                iterable << [param_model.param_new[k] for k in ('coherent_sct_energy',)]
+                Label:
+                    text = loop_item['description']
+                    maximum_size = 140
+                Container: cont:
+                    padding = Box(2, 2, 2, 2)
+                    constraints = [hbox(ff_incident_energy, pb_bd_default)]
+                    FloatField: ff_incident_energy:
+                        value := plot_model.incident_energy
+                        value ::
+                            io_model.incident_energy_set = value
+                        maximum_size = 100
+                    PushButton: pb_bd_default:
+                        text = 'Default'
+                        maximum_size = 100
+                        clicked ::
+                            ff_incident_energy.value = loop_item['default_value']
+
             Looper: 
                 iterable << [param_model.param_new['non_fitting_values'][k] for k in ('energy_bound_high',)]
                 Label:


### PR DESCRIPTION
The following issues were fixed:

- GUI: data loaded from databroker using GUI controls was always saved to the current directory (from which PyXRF was started). In fixed version, data is saved to the working directory, selected in the dialog box opened using ``Working Directory`` button in ``File IO`` tab.

- GUI: fixed the issue with synchronization of the value of incident energy displayed in ``Automated Element Search`` window.

- GUI: fixed the issue with synchronization of calibration data preview and the ``distance-to-sample`` field in ``Save Quantitative Standard`` window.

- Changed computational code for quantitative calibration. Pixels along the edges of the map are likely to include outliers that visibly bias the computed calibration coefficients. In the changed code, all pixels along edges are ignored if the size of the map allows it. For example, if calibration is based on 1 or 2 row scan, all rows will be used to compute the calibration coefficient.