### PR TITLE
ENH: improved management of user defined peaks

### DIFF
--- a/pyxrf/gui.py
+++ b/pyxrf/gui.py
@@ -135,6 +135,9 @@ def run():
 
     param_model.observe('energy_bound_high_buf', fit_model.energy_bound_high_update)
     param_model.observe('energy_bound_low_buf', fit_model.energy_bound_low_update)
+    param_model.observe('energy_bound_high_buf', plot_model.energy_bound_high_update)
+    param_model.observe('energy_bound_low_buf', plot_model.energy_bound_low_update)
+
 
     #  set default parameters
     # io_model.observe('default_parameters', plot_model.parameters_update)

--- a/pyxrf/gui.py
+++ b/pyxrf/gui.py
@@ -138,7 +138,6 @@ def run():
     param_model.observe('energy_bound_high_buf', plot_model.energy_bound_high_update)
     param_model.observe('energy_bound_low_buf', plot_model.energy_bound_low_update)
 
-
     #  set default parameters
     # io_model.observe('default_parameters', plot_model.parameters_update)
     # param_model.observe('param_new', plot_model.parameters_update)

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -594,7 +594,7 @@ class Fit1D(Atom):
         (the peak should be selected at the time of creation!!!)
         """
         if (self.name_userpeak_dcenter not in self.param_dict) or \
-            (self.name_userpeak_dsigma not in self.param_dict):
+                (self.name_userpeak_dsigma not in self.param_dict):
             return
         # Set energy
         v_center = self.param_dict[self.name_userpeak_dcenter]["value"]

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -593,6 +593,9 @@ class Fit1D(Atom):
         for userpeak energy and fwhm. Uses data for the currently selected Userpeak
         (the peak should be selected at the time of creation!!!)
         """
+        if (self.name_userpeak_dcenter not in self.param_dict) or \
+            (self.name_userpeak_dsigma not in self.param_dict):
+            return
         # Set energy
         v_center = self.param_dict[self.name_userpeak_dcenter]["value"]
         v_energy = v_center + 5.0

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -433,38 +433,7 @@ class Fit1D(Atom):
 
         sigma = gaussian_fwhm_to_sigma(self.param_model.default_parameters["fwhm_offset"]["value"])
 
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        # The error was detected in scikit-beam, but not corrected
-        # Note: Corrections are required in the function ``element_peak_xrf``
-        #   from file ``xrf_model.py`` (package Scikit-Beam)
-        # The error: the original center position for the peak was used to
-        #   compute sigma of the Gaussian approximation of the peak. It almost not matter
-        #   for element peaks, since they don't move along the energy axis. But it is
-        #   invalid for Userpeaks, which are placed at a fixed position (5 keV) and then
-        #   moved to the desired position by changing ``delta_center``. Sigma depends
-        #   on actual center position, so ``delta_center`` should be taken into account.
-        #
-        # The original code for computing Gaussian function:
-        # def get_sigma(center):
-        #     temp_val = 2 * np.sqrt(2 * np.log(2))
-        #     return np.sqrt((fwhm_offset / temp_val) ** 2 + center * epsilon * fwhm_fanoprime)
-        #
-        # x = e_offset + x * e_linear + x ** 2 * e_quadratic
-        #
-        # return gaussian(x, area, center + delta_center,
-        #                 delta_sigma + get_sigma(center)) * ratio * ratio_adjust
-        #
-        # To correct the error, the last statement should be changed to the following:
-        # return gaussian(x, area, center + delta_center,
-        #                 delta_sigma + get_sigma(center + delta_center)) * ratio * ratio_adjust
-
-        # Temporary fix for the error mentioned above (to keep peak hight consistent as it moves
-        #   along the enery axis, computation of sigma must be identical here and in
-        #   the function ``element_peak_xrf``
-        sigma_sqr = 5.0  # center (ignore ``delta_sigma``)
-        # The next line is correct (but may be enabled only if the bug in scikit-beam is corrected)
-        # sigma_sqr = self.param_dict[self.name_userpeak_dcenter]["value"] + 5.0  # center
-
+        sigma_sqr = self.param_dict[self.name_userpeak_dcenter]["value"] + 5.0  # center
         sigma_sqr *= self.param_model.default_parameters["non_fitting_values"]["epsilon"]  # epsilon
         sigma_sqr *= self.param_model.default_parameters["fwhm_fanoprime"]["value"]  # fanoprime
         sigma_sqr += sigma * sigma  # We have computed the expression under sqrt

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -584,6 +584,25 @@ class Fit1D(Atom):
                      f"          Energy: {self.add_userpeak_energy} keV\n"
                      f"          FWHM: {self.add_userpeak_fwhm} keV")
 
+    def update_userpeak_controls(self):
+        """
+        The function should be called right after adding a userpeak to update the fields
+        for userpeak energy and fwhm. Uses data for the currently selected Userpeak
+        (the peak should be selected at the time of creation!!!)
+        """
+        # Set energy
+        v_center = self.param_dict[self.name_userpeak_dcenter]["value"]
+        v_energy = v_center + 5.0
+        v_energy = round(v_energy, 3)
+        self.add_userpeak_energy = v_energy
+        # Set fwhm
+        fwhm_base = self._compute_fwhm_base()
+        v_dsigma = self.param_dict[self.name_userpeak_dsigma]["value"]
+        v_dfwhm = gaussian_sigma_to_fwhm(v_dsigma)
+        v_fwhm = v_dfwhm + fwhm_base
+        v_fwhm = round(v_fwhm, 5)
+        self.add_userpeak_fwhm = v_fwhm
+
     def keep_size(self):
         """Keep the size of deque as 2.
         """

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -463,7 +463,7 @@ class GuessParamModel(Atom):
 
     def manual_input(self, userpeak_center=2.5):
         """
-        Manually add emission line (or peak)
+        Manually add an emission line (or peak).
 
         Parameters
         ----------

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -512,7 +512,7 @@ class GuessParamModel(Atom):
 
         # 'self.param_new' is used to provide 'hint' values for the model, but all active
         #    emission lines in 'elemental_lines' will be included in the model.
-        #  The model will contain lines in 'elemental_lines', Compton and ellastic
+        #  The model will contain lines in 'elemental_lines', Compton and elastic
         x, data_out, area_dict = calculate_profile(self.x0,
                                                    self.y0,
                                                    param_tmp,

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -507,12 +507,7 @@ class GuessParamModel(Atom):
             PC.params[f"{self.e_name}_delta_center"]["value"] = d_energy
             PC.params[f"{self.e_name}_delta_center"]["min"] = d_energy - (dc["value"] - dc["min"])
             PC.params[f"{self.e_name}_delta_center"]["max"] = d_energy + (dc["max"] - dc["value"])
-            # 'param_tmp' temporary (possibly extended) set of parameters.
-            #param_tmp = PC.params
-        #else:
-            # For all other emission lines we (probably) don't need to create parameters at this
-            #   point, since they are initially used with default parameter values.
-        #    param_tmp = self.param_new
+
         param_tmp = PC.params
 
         # 'self.param_new' is used to provide 'hint' values for the model, but all active

--- a/pyxrf/model/guessparam.py
+++ b/pyxrf/model/guessparam.py
@@ -485,7 +485,8 @@ class GuessParamModel(Atom):
                                                    self.y0,
                                                    self.param_new,
                                                    elemental_lines=[self.e_name],
-                                                   default_area=default_area)
+                                                   default_area=default_area,
+                                                   default_userpeak_center=2.5)
 
         # Check if element profile was calculated successfully.
         #   Calculation may fail if the selected line is not activated.
@@ -756,7 +757,7 @@ def define_range(data, low, high, a0, a1):
 
 
 def calculate_profile(x, y, param, elemental_lines,
-                      default_area=1e5):
+                      default_area=1e5, default_userpeak_center=None):
     """
     Calculate the spectrum profile based on given paramters. Use function
     construct_linear_model from xrf_model.
@@ -776,6 +777,9 @@ def calculate_profile(x, y, param, elemental_lines,
         predifine the length to a given value.
     default_area : float
         default value for the gaussian area of each element
+    default_userpeak_center: float
+        location of the center of the new user defined peaks that are being added,
+        if None, then the peaks are placed in the location defined by the built-in parameter
 
     Returns
     -------
@@ -792,7 +796,8 @@ def calculate_profile(x, y, param, elemental_lines,
     total_list, matv, area_dict = construct_linear_model(x,
                                                          fitting_parameters,
                                                          elemental_lines,
-                                                         default_area=default_area)
+                                                         default_area=default_area,
+                                                         default_userpeak_center=default_userpeak_center)
 
     temp_d = {k: v for (k, v) in zip(total_list, matv.transpose())}
 

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -149,6 +149,10 @@ class LinePlotModel(Atom):
     # Reference to GuessParamModel object
     param_model = Typed(object)
 
+    # Location of the vertical (mouse-selected) marker on the plot.
+    # Value is in kev. Negative value - no marker is placed.
+    plot_vertical_marker_kev = Float(-1)
+
     def __init__(self, param_model):
 
         # Reference to GuessParamModel object
@@ -178,6 +182,8 @@ class LinePlotModel(Atom):
         # And the last point of data is also huge, and should be cut off.
         self.limit_cut = 100
         # self._ax.margins(x=0.0, y=0.10)
+
+        self.plot_vertical_marker_kev = 2.0
 
     def _color_config(self):
         self.plot_style = {

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -1360,8 +1360,9 @@ class LinePlotModel(Atom):
     def canvas_onpress(self, event):
         """Callback, mouse button pressed"""
         if (self.t_bar.mode == ""):
-            if (event.inaxes == self._ax) and (event.button == 1):
-                xd = event.xdata
-                self.set_plot_vertical_marker(marker_position=xd)
-            else:
-                self.hide_plot_vertical_marker()
+            if event.inaxes == self._ax:
+                if event.button == 1:
+                    xd = event.xdata
+                    self.set_plot_vertical_marker(marker_position=xd)
+                else:
+                    self.hide_plot_vertical_marker()

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -511,7 +511,7 @@ class LinePlotModel(Atom):
 
         if self.line_vertical_marker:
             self._ax.lines.remove(self.line_vertical_marker)
-            self.line_vertical_marker=None
+            self.line_vertical_marker = None
         if self.vertical_marker_is_visible:
             self.line_vertical_marker, = self._ax.plot(x_v, y_v, color="blue")
 
@@ -848,24 +848,24 @@ class LinePlotModel(Atom):
                 if e.cs(incident_energy)['ka1'] != 0:
                     for i in range(k_len):
                         _elist.append((e.emission_line.all[i][1],
-                                           e.cs(incident_energy).all[i][1]
-                                           / e.cs(incident_energy).all[0][1]))
+                                       e.cs(incident_energy).all[i][1]
+                                       / e.cs(incident_energy).all[0][1]))
 
             elif '_L' in ename:
                 e = Element(ename[:-2])
                 if e.cs(incident_energy)['la1'] != 0:
                     for i in range(k_len, k_len+l_len):
                         _elist.append((e.emission_line.all[i][1],
-                                           e.cs(incident_energy).all[i][1]
-                                           / e.cs(incident_energy).all[k_len][1]))
+                                       e.cs(incident_energy).all[i][1]
+                                       / e.cs(incident_energy).all[k_len][1]))
 
             else:
                 e = Element(ename[:-2])
                 if e.cs(incident_energy)['ma1'] != 0:
                     for i in range(k_len+l_len, k_len+l_len+m_len):
                         _elist.append((e.emission_line.all[i][1],
-                                           e.cs(incident_energy).all[i][1]
-                                           / e.cs(incident_energy).all[k_len+l_len][1]))
+                                       e.cs(incident_energy).all[i][1]
+                                       / e.cs(incident_energy).all[k_len+l_len][1]))
 
             return _elist
 
@@ -1018,8 +1018,8 @@ class LinePlotModel(Atom):
 
             e_raw_min = self.parameters['e_offset']['value']
             e_raw_max = self.parameters['e_offset']['value'] + \
-                        (len(self.data) - 1) * self.parameters['e_linear']['value'] + \
-                        (len(self.data) - 1) ** 2 * self.parameters['e_quadratic']['value']
+                (len(self.data) - 1) * self.parameters['e_linear']['value'] + \
+                (len(self.data) - 1) ** 2 * self.parameters['e_quadratic']['value']
             de_raw = (e_raw_max - e_raw_min) / (len(self.data) - 1)
 
             # Note: the above algorithm for finding 'de_raw' is far from perfect but will
@@ -1361,7 +1361,7 @@ class LinePlotModel(Atom):
         """Callback, mouse button pressed"""
         if (self.t_bar.mode == ""):
             if (event.inaxes == self._ax) and (event.button == 1):
-                xd, yd = event.xdata, event.ydata
+                xd = event.xdata
                 self.set_plot_vertical_marker(marker_position=xd)
             else:
                 self.hide_plot_vertical_marker()

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -803,7 +803,7 @@ class LinePlotModel(Atom):
 
     def add_peak_manual(self):
 
-        self.param_model.manual_input()
+        self.param_model.manual_input(userpeak_center=2.0)
         self.param_model.EC.update_peak_ratio()
         self.param_model.update_name_list()
         self.param_model.data_for_plot()

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -156,7 +156,10 @@ class LinePlotModel(Atom):
 
     # Location of the vertical (mouse-selected) marker on the plot.
     # Value is in kev. Negative value - no marker is placed.
-    plot_vertical_marker_kev = Float(-1)
+    vertical_marker_kev = Float(-1)
+    # Reference to the respective Matplotlib artist
+    line_vertical_marker = Typed(object)
+    vertical_marker_is_visible = Bool(False)
 
     def __init__(self, param_model):
 
@@ -188,8 +191,6 @@ class LinePlotModel(Atom):
         # And the last point of data is also huge, and should be cut off.
         self.limit_cut = 100
         # self._ax.margins(x=0.0, y=0.10)
-
-        self.plot_vertical_marker_kev = 2.0
 
     def _color_config(self):
         self.plot_style = {
@@ -241,6 +242,7 @@ class LinePlotModel(Atom):
         # It may be sufficient to initialize the event only once, but at this point
         #   it seems to be the most reliable option. May be changed in the future.
         self.init_mouse_event()
+        self.plot_vertical_marker()
 
         self._ax.legend(loc=2)
         try:
@@ -342,6 +344,7 @@ class LinePlotModel(Atom):
         if self.data is None:
             return
         self.plot_selected_energy_range(e_high=change["value"])
+        self.plot_vertical_marker(e_high=change["value"])
         self._update_canvas()
 
     def energy_bound_low_update(self, change):
@@ -349,6 +352,7 @@ class LinePlotModel(Atom):
         if self.data is None:
             return
         self.plot_selected_energy_range(e_low=change["value"])
+        self.plot_vertical_marker(e_low=change["value"])
         self._update_canvas()
 
     def log_linear_plot(self):
@@ -497,6 +501,51 @@ class LinePlotModel(Atom):
 
         data_arr = np.asarray(self.data)
         self.exp_data_update({'value': data_arr})
+
+    def plot_vertical_marker(self, *, e_low=None, e_high=None):
+
+        self._vertical_marker_set_inside_range(e_low=e_low, e_high=e_high)
+
+        x_v = (self.vertical_marker_kev, self.vertical_marker_kev)
+        y_v = (-1e30, 1e30)  # This will cover the range of possible values of accumulated counts
+
+        if self.line_vertical_marker:
+            self._ax.lines.remove(self.line_vertical_marker)
+            self.line_vertical_marker=None
+        if self.vertical_marker_is_visible:
+            self.line_vertical_marker, = self._ax.plot(x_v, y_v, color="blue")
+
+    def set_plot_vertical_marker(self, marker_position=None):
+        """
+        The function is called when setting the position of the marker interactively
+
+        If the parameter `marker_position` is `None`, then don't set or change the value.
+        Just make the marker visible.
+        """
+
+        # Ignore the new value if it is outside the range of selected energies
+        if marker_position is not None:
+            e_low = self.param_model.param_new['non_fitting_values']['energy_bound_low']['value']
+            e_high = self.param_model.param_new['non_fitting_values']['energy_bound_high']['value']
+            if (marker_position >= e_low) and (marker_position <= e_high):
+                self.vertical_marker_kev = marker_position
+
+        # Compute peak intensity. The displayed value will change only for user defined peak,
+        #   since it is moved to the position of the marker.
+        self.compute_manual_peak_intensity()
+
+        # Make the marker visible
+        self.vertical_marker_is_visible = True
+
+        # Update the location of the marker and the canvas
+        self.plot_vertical_marker()
+        self._update_canvas()
+
+    def hide_plot_vertical_marker(self):
+        """Hide vertical marker"""
+        self.vertical_marker_is_visible = False
+        self.plot_vertical_marker()
+        self._update_canvas()
 
     def plot_selected_energy_range(self, *, e_low=None, e_high=None):
         """
@@ -758,6 +807,68 @@ class LinePlotModel(Atom):
             ename = None
         return ename
 
+    def _vertical_marker_set_inside_range(self, *, e_low=None, e_high=None):
+        """
+        Don't move the marker if it is inside range. If it is outside range,
+        then set the marker to the center of the range
+        """
+        # The range of energy selected for analysis
+        if e_low is None:
+            e_low = self.param_model.param_new['non_fitting_values']['energy_bound_low']['value']
+        if e_high is None:
+            e_high = self.param_model.param_new['non_fitting_values']['energy_bound_high']['value']
+
+        # By default, place the marker in the middle of the range if its original position
+        #   is outside the range
+        if (self.vertical_marker_kev > e_high) or (self.vertical_marker_kev < e_low):
+            self.vertical_marker_kev = (e_low + e_high) / 2.0
+
+    def _fill_elist(self):
+
+        _elist = []
+
+        incident_energy = self.incident_energy
+        k_len = len(K_TRANSITIONS)
+        l_len = len(L_TRANSITIONS)
+        m_len = len(M_TRANSITIONS)
+
+        ename = self.get_element_line_name_by_id(self.element_id, include_user_peaks=True)
+
+        if ename is not None:
+
+            _elist = []
+            if ename.lower().startswith("userpeak"):
+                # Make sure that the marker is in the selected range of energies
+                self._vertical_marker_set_inside_range()
+                # The tuple structure: (center_energy, ratio)
+                _elist.append((self.vertical_marker_kev, 1.0))
+
+            elif '_K' in ename:
+                e = Element(ename[:-2])
+                if e.cs(incident_energy)['ka1'] != 0:
+                    for i in range(k_len):
+                        _elist.append((e.emission_line.all[i][1],
+                                           e.cs(incident_energy).all[i][1]
+                                           / e.cs(incident_energy).all[0][1]))
+
+            elif '_L' in ename:
+                e = Element(ename[:-2])
+                if e.cs(incident_energy)['la1'] != 0:
+                    for i in range(k_len, k_len+l_len):
+                        _elist.append((e.emission_line.all[i][1],
+                                           e.cs(incident_energy).all[i][1]
+                                           / e.cs(incident_energy).all[k_len][1]))
+
+            else:
+                e = Element(ename[:-2])
+                if e.cs(incident_energy)['ma1'] != 0:
+                    for i in range(k_len+l_len, k_len+l_len+m_len):
+                        _elist.append((e.emission_line.all[i][1],
+                                           e.cs(incident_energy).all[i][1]
+                                           / e.cs(incident_energy).all[k_len+l_len][1]))
+
+            return _elist
+
     @observe('element_id')
     def set_element(self, change):
 
@@ -775,43 +886,19 @@ class LinePlotModel(Atom):
             return
 
         incident_energy = self.incident_energy
-        k_len = len(K_TRANSITIONS)
-        l_len = len(L_TRANSITIONS)
-        m_len = len(M_TRANSITIONS)
-
-        ename = self.get_element_line_name_by_id(self.element_id)
+        ename = self.get_element_line_name_by_id(self.element_id, include_user_peaks=True)
 
         if ename is not None:
 
             logger.debug('Plot emission line for element: '
                          '{} with incident energy {}'.format(self.element_id,
                                                              incident_energy))
-            self.elist = []
 
-            if '_K' in ename:
-                e = Element(ename[:-2])
-                if e.cs(incident_energy)['ka1'] != 0:
-                    for i in range(k_len):
-                        self.elist.append((e.emission_line.all[i][1],
-                                           e.cs(incident_energy).all[i][1]
-                                           / e.cs(incident_energy).all[0][1]))
-
-            elif '_L' in ename:
-                e = Element(ename[:-2])
-                if e.cs(incident_energy)['la1'] != 0:
-                    for i in range(k_len, k_len+l_len):
-                        self.elist.append((e.emission_line.all[i][1],
-                                           e.cs(incident_energy).all[i][1]
-                                           / e.cs(incident_energy).all[k_len][1]))
-
+            _elist = self._fill_elist()
+            if not ename.lower().startswith("userpeak"):
+                self.elist = _elist
             else:
-                e = Element(ename[:-2])
-                if e.cs(incident_energy)['ma1'] != 0:
-                    for i in range(k_len+l_len, k_len+l_len+m_len):
-                        self.elist.append((e.emission_line.all[i][1],
-                                           e.cs(incident_energy).all[i][1]
-                                           / e.cs(incident_energy).all[k_len+l_len][1]))
-
+                self.elist = []
             self.plot_emission_line()
             self._update_canvas()
 
@@ -874,10 +961,12 @@ class LinePlotModel(Atom):
 
     def add_peak_manual(self):
 
-        self.param_model.manual_input(userpeak_center=2.0)
+        self.param_model.manual_input(userpeak_center=self.vertical_marker_kev)
         self.param_model.EC.update_peak_ratio()
         self.param_model.update_name_list()
         self.param_model.data_for_plot()
+
+        self.hide_plot_vertical_marker()
 
         self.plot_fit(self.param_model.prefit_x,
                       self.param_model.total_y,
@@ -914,12 +1003,70 @@ class LinePlotModel(Atom):
         self.show_fit_opt = True
         self.param_model.update_name_list()
 
+    def _compute_intensity(self, elist):
+        # Some default value
+        intensity = 1000.0
+
+        if self.data is not None and self.parameters is not None \
+                and self.param_model.prefit_x is not None \
+                and len(self.data) > 1 and len(self.param_model.prefit_x) > 1:
+
+            # Range of energies in fitting results
+            e_fit_min = self.param_model.prefit_x[0]
+            e_fit_max = self.param_model.prefit_x[-1]
+            de_fit = (e_fit_max - e_fit_min) / (len(self.param_model.prefit_x) - 1)
+
+            e_raw_min = self.parameters['e_offset']['value']
+            e_raw_max = self.parameters['e_offset']['value'] + \
+                        (len(self.data) - 1) * self.parameters['e_linear']['value'] + \
+                        (len(self.data) - 1) ** 2 * self.parameters['e_quadratic']['value']
+            de_raw = (e_raw_max - e_raw_min) / (len(self.data) - 1)
+
+            # Note: the above algorithm for finding 'de_raw' is far from perfect but will
+            #    work for now. As a result 'de_fit' and 'de_raw' == self.parameters['e_linear']['value'].
+            #    So the quadratic coefficent is ignored. This is OK, since currently
+            #    quadratic coefficient is always ZERO. When the program is rewritten,
+            #    the complete algorithm should be revised.
+
+            # Find the line with maximum energy. It must come first in the list,
+            #    but let's check just to make sure
+            max_line_energy, max_line_intensity = 0, 0
+            if elist:
+                for e, i in elist:
+                    # e - line peak energy
+                    # i - peak intensity relative to maximum peak
+                    if e >= e_fit_min and e <= e_fit_max and e > e_raw_min and e < e_raw_max:
+                        if max_line_intensity < i:
+                            max_line_energy, max_line_intensity = e, i
+
+            # Find the index of peak maximum in the 'fitted' data array
+            n = (max_line_energy - e_fit_min) / de_fit
+            n = np.clip(n, 0, len(self.param_model.total_y) - 1)
+            n_fit = int(round(n))
+            # Find the index of peak maximum in the 'raw' data array
+            n = (max_line_energy - e_raw_min) / de_raw
+            n = np.clip(n, 0, len(self.data) - 1)
+            n_raw = int(round(n))
+            # Intensity of the fitted data at the peak
+            in_fit = self.param_model.total_y[n_fit]
+            # Intensity of the raw data at the peak
+            in_raw = self.data[n_raw]
+            # The estimated peak intensity is the difference:
+            intensity = in_raw - in_fit
+
+            # The following step is questionable. We assign some reasonably small number.
+            #   The desired value can always be manually entered
+            if intensity < 0.0:
+                intensity = abs(in_raw / 100)
+
+        return intensity
+
     def compute_manual_peak_intensity(self, n_id=None):
 
         if n_id is None:
             n_id = self.element_id
 
-        if not self.is_element_line_id_valid(n_id):
+        if not self.is_element_line_id_valid(n_id, include_user_peaks=True):
             # This is typicall the case when n_id==0
             intensity = 0.0
             if self.is_element_line_id_valid(n_id, include_user_peaks=True):
@@ -929,70 +1076,15 @@ class LinePlotModel(Atom):
                     intensity = self.param_model.EC.element_dict[name].maxv
 
         else:
-            if self.is_line_in_selected_list(n_id):
-                name = self.get_element_line_name_by_id(n_id)
+            if self.is_line_in_selected_list(n_id, include_user_peaks=True):
+                name = self.get_element_line_name_by_id(n_id, include_user_peaks=True)
                 intensity = self.param_model.EC.element_dict[name].maxv
-
             else:
+                _elist = self._fill_elist()
+                intensity = self._compute_intensity(_elist)
 
-                # Some default value
-                intensity = 1000.0
-
-                if self.data is not None and self.parameters is not None \
-                        and self.param_model.prefit_x is not None \
-                        and len(self.data) > 1 and len(self.param_model.prefit_x) > 1:
-
-                    # Range of energies in fitting results
-                    e_fit_min = self.param_model.prefit_x[0]
-                    e_fit_max = self.param_model.prefit_x[-1]
-                    de_fit = (e_fit_max - e_fit_min) / (len(self.param_model.prefit_x) - 1)
-
-                    e_raw_min = self.parameters['e_offset']['value']
-                    e_raw_max = self.parameters['e_offset']['value'] + \
-                        (len(self.data) - 1) * self.parameters['e_linear']['value'] + \
-                        (len(self.data) - 1) ** 2 * self.parameters['e_quadratic']['value']
-                    de_raw = (e_raw_max - e_raw_min) / (len(self.data) - 1)
-
-                    # Note: the above algorithm for finding 'de_raw' is far from perfect but will
-                    #    work for now. As a result 'de_fit' and 'de_raw' == self.parameters['e_linear']['value'].
-                    #    So the quadratic coefficent is ignored. This is OK, since currently
-                    #    quadratic coefficient is always ZERO. When the program is rewritten,
-                    #    the complete algorithm should be revised.
-
-                    # Find the line with maximum energy. It must come first in the list,
-                    #    but let's check just to make sure
-                    max_line_energy, max_line_intensity = 0, 0
-                    if self.elist:
-                        for e, i in self.elist:
-                            # e - line peak energy
-                            # i - peak intensity relative to maximum peak
-                            if e >= e_fit_min and e <= e_fit_max and e > e_raw_min and e < e_raw_max:
-                                if max_line_intensity < i:
-                                    max_line_energy, max_line_intensity = e, i
-
-                    # Find the index of peak maximum in the 'fitted' data array
-                    n = (max_line_energy - e_fit_min) / de_fit
-                    n = np.clip(n, 0, len(self.param_model.total_y) - 1)
-                    n_fit = int(round(n))
-                    # Find the index of peak maximum in the 'raw' data array
-                    n = (max_line_energy - e_raw_min) / de_raw
-                    n = np.clip(n, 0, len(self.data) - 1)
-                    n_raw = int(round(n))
-                    # Intensity of the fitted data at the peak
-                    in_fit = self.param_model.total_y[n_fit]
-                    # Intensity of the raw data at the peak
-                    in_raw = self.data[n_raw]
-                    # The estimated peak intensity is the difference:
-                    intensity = in_raw - in_fit
-
-                    # The following step is questionable. We assign some reasonably small number.
-                    #   The desired value can always be manually entered
-                    if intensity < 0.0:
-                        intensity = abs(in_raw / 100)
-
-        # Round for nicer printing
-        intensity = float(f"{intensity:.2f}")
-        self.param_model.add_element_intensity = intensity
+        # Round the intensity for nicer printing
+        self.param_model.add_element_intensity = round(intensity, 2)
 
     # def plot_autofit(self):
     #     sum_y = 0
@@ -1267,10 +1359,9 @@ class LinePlotModel(Atom):
 
     def canvas_onpress(self, event):
         """Callback, mouse button pressed"""
-        #self.button_pressed = False  # May be pressed outside the region
-        if (self.t_bar.mode == "") and (event.inaxes == self._ax) and (event.button == 1):
-        #if (event.inaxes == self._ax) and (event.button == 1):
-            #self.button_pressed = True  # Left mouse button is in pressed state
-            #     and it was pressed when the cursor was inside the plot area
-            xd, yd = event.xdata, event.ydata
-            print(f"xd = {xd}, yd = {yd}")
+        if (self.t_bar.mode == ""):
+            if (event.inaxes == self._ax) and (event.button == 1):
+                xd, yd = event.xdata, event.ydata
+                self.set_plot_vertical_marker(marker_position=xd)
+            else:
+                self.hide_plot_vertical_marker()

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -111,6 +111,7 @@ class LinePlotModel(Atom):
 
     # Reference to artist responsible for displaying the selected range of energies on the plot
     plot_energy_barh = Typed(BrokenBarHCollection)
+    t_bar = Typed(object)
 
     plot_exp_list = List()
     data_sets = Typed(OrderedDict)
@@ -165,6 +166,7 @@ class LinePlotModel(Atom):
         self.data = None
 
         self._fig = plt.figure(figsize=(3, 2))
+
         self._ax = self._fig.add_subplot(111)
         try:
             self._ax.set_axis_bgcolor('lightgrey')
@@ -188,6 +190,7 @@ class LinePlotModel(Atom):
         # self._ax.margins(x=0.0, y=0.10)
 
         self.plot_vertical_marker_kev = 2.0
+        # self._fig.canvas.mpl_connect("button_press_event", self.canvas_onpress)
 
     def _color_config(self):
         self.plot_style = {
@@ -551,6 +554,11 @@ class LinePlotModel(Atom):
                 m += 1
 
         self.plot_selected_energy_range()
+
+        # Reference to the toolbar
+        self.t_bar = self._fig.canvas.toolbar
+        # Set callback for Button Press event
+        self._fig.canvas.mpl_connect("button_press_event", self.canvas_onpress)
 
         self._update_ylimit()
         self.log_linear_plot()
@@ -1251,3 +1259,13 @@ class LinePlotModel(Atom):
                 pass
 
         # self._update_canvas()
+
+    def canvas_onpress(self, event):
+        """Callback, mouse button pressed"""
+        #self.button_pressed = False  # May be pressed outside the region
+        if (self.t_bar.mode == "") and (event.inaxes == self._ax) and (event.button == 1):
+        #if (event.inaxes == self._ax) and (event.button == 1):
+            #self.button_pressed = True  # Left mouse button is in pressed state
+            #     and it was pressed when the cursor was inside the plot area
+            xd, yd = event.xdata, event.ydata
+            print(f"xd = {xd}, yd = {yd}")

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -190,7 +190,6 @@ class LinePlotModel(Atom):
         # self._ax.margins(x=0.0, y=0.10)
 
         self.plot_vertical_marker_kev = 2.0
-        # self._fig.canvas.mpl_connect("button_press_event", self.canvas_onpress)
 
     def _color_config(self):
         self.plot_style = {
@@ -231,7 +230,18 @@ class LinePlotModel(Atom):
         # Reset currently selected element_id (mostly to reset GUI elements)
         self.element_id = 0
 
+    def init_mouse_event(self):
+        """Set up callback for mouse button-press event"""
+        # Reference to the toolbar
+        self.t_bar = self._fig.canvas.toolbar
+        # Set callback for Button Press event
+        self._fig.canvas.mpl_connect("button_press_event", self.canvas_onpress)
+
     def _update_canvas(self):
+        # It may be sufficient to initialize the event only once, but at this point
+        #   it seems to be the most reliable option. May be changed in the future.
+        self.init_mouse_event()
+
         self._ax.legend(loc=2)
         try:
             self._ax.legend(framealpha=0.2).set_draggable(True)
@@ -554,11 +564,6 @@ class LinePlotModel(Atom):
                 m += 1
 
         self.plot_selected_energy_range()
-
-        # Reference to the toolbar
-        self.t_bar = self._fig.canvas.toolbar
-        # Set callback for Button Press event
-        self._fig.canvas.mpl_connect("button_press_event", self.canvas_onpress)
 
         self._update_ylimit()
         self.log_linear_plot()

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -424,6 +424,13 @@ enamldef FitView(DockItem): fit_view:
                 clicked ::
                     plot_model.remove_peak_manual(param_model.e_name)
                     cb_select.set_focus()  # Return focus to the combo box
+                    # Completely remove userpeaks from all dictionaries. This operation
+                    #   takes considerable time, so do it only for userpeaks. For other
+                    #   peaks, the button 'Update' needs to be pressed to completely
+                    #   remove peaks (this is faster and enables 'Undo').
+                    if "userpeak" in param_model.e_name.lower():
+                        param_model.update_name_list()
+                        apply_to_fit(param_model, plot_model, fit_model, setting_model)
 
             PushButton: pb_pileup:
                 text = 'Add Pileup Peaks'

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -412,6 +412,7 @@ enamldef FitView(DockItem): fit_view:
                                 plot_model.plot_fit(param_model.prefit_x,
                                                     param_model.total_y,
                                                     param_model.auto_fit_all)
+                                fit_model.update_userpeak_controls()
                         except Exception as ex:
                             pass
 

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -841,6 +841,9 @@ enamldef FitView(DockItem): fit_view:
                         # Update displayed intensity of the selected peak
                         plot_model.compute_manual_peak_intensity()
 
+                        # Amplitude and FWHM may change in the process of fitting. Update the controls.
+                        fit_model.update_userpeak_controls()
+
                     else:
 
                         btns = [DialogButton('Ok', 'accept')]

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -370,7 +370,11 @@ enamldef FitView(DockItem): fit_view:
                             try:
                                 if "Userpeak" in cb_select.selected_item:
                                     fit_model.select_index_by_eline_name(cb_select.selected_item)
+                                    # Show the marker at the center of the userpeak
+                                    plot_model.set_plot_vertical_marker(fit_model.add_userpeak_energy)
                             except Exception as ex:
+                                # Show the marker at its current or default location
+                                plot_model.set_plot_vertical_marker()
                                 pass
 
             Label: intensity_lb:
@@ -385,12 +389,22 @@ enamldef FitView(DockItem): fit_view:
                 text = 'Add'
                 enabled << (cb_select.index > 0) and plot_model.allow_add_eline_fit
                 clicked ::
+                    # Verify if we are adding a userpeak
+                    is_userpeak = False
+                    ename = plot_model.get_element_line_name_by_id(plot_model.element_id, include_user_peaks=True)
+                    if ename and (ename.lower().startswith("userpeak")):
+                        is_userpeak = True
+
                     # The following set of conditions is not complete, but sufficient
                     if param_model.x0 is None or param_model.y0 is None:
-
                         btns = [DialogButton('Ok', 'accept')]
                         # 'critical' shows MessageBox
                         critical(self, 'ERROR', f'Experimental data is not loaded or initial spectrum fitting is not performed', btns)
+
+                    elif is_userpeak and (not plot_model.vertical_marker_is_visible):
+                        btns = [DialogButton('Ok', 'accept')]
+                        # 'critical' shows MessageBox
+                        critical(self, '', f'Select position of userpeak by clicking at the plot', btns)
 
                     else:
                         try:


### PR DESCRIPTION
The changes in the PR:

- Display the range of selected energies on the spectrum plot (`Spectrum View` tab).

- A new option to interactively select initial location of user defined peaks. Initial amplitude of the user peak is estimated automatically using the same algorithm as for element emission lines.

- Fixed the bug that prevented normal operation of the program after attempt to add user defined peaks if upper bound on the selected range of energies is below 5.0 keV (needed for data produced by TES beamline).

- Fixed the bug that may have caused rare cases of deletion of emission lines from the list of selected lines.