### PR TITLE
XANES mapping: using any existing map for stack alignment

### DIFF
--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -2120,11 +2120,10 @@ def single_pixel_fitting_controller(input_data, parameter,
     for eline in elist_non_activated:
         result_map[eline] = np.zeros(shape=exp_data.shape[0:2])
 
-    # Compute total count
+    # Compute total count for each pixel
     total_count = np.sum(input_data, axis=2)
-    # Save it as rearely used emission line
-    # TODO: implement saving of total count in appropriate way
-    result_map['U_M'] = total_count
+    # Save the map as 'total_count'
+    result_map['total_count'] = total_count
 
     calculation_info = dict()
     if error_map is not None:

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -2122,8 +2122,8 @@ def single_pixel_fitting_controller(input_data, parameter,
 
     # Compute total count for each pixel
     total_count = np.sum(input_data, axis=2)
-    # Save the map as 'total_count'
-    result_map['total_count'] = total_count
+    # Save the map as 'total_cnt'
+    result_map['total_cnt'] = total_count
 
     calculation_info = dict()
     if error_map is not None:

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -2120,6 +2120,12 @@ def single_pixel_fitting_controller(input_data, parameter,
     for eline in elist_non_activated:
         result_map[eline] = np.zeros(shape=exp_data.shape[0:2])
 
+    # Compute total count
+    total_count = np.sum(input_data, axis=2)
+    # Save it as rearely used emission line
+    # TODO: implement saving of total count in appropriate way
+    result_map['U_M'] = total_count
+
     calculation_info = dict()
     if error_map is not None:
         calculation_info['error_map'] = error_map

--- a/pyxrf/view/fit.enaml
+++ b/pyxrf/view/fit.enaml
@@ -404,7 +404,8 @@ enamldef FitView(DockItem): fit_view:
                     elif is_userpeak and (not plot_model.vertical_marker_is_visible):
                         btns = [DialogButton('Ok', 'accept')]
                         # 'critical' shows MessageBox
-                        critical(self, '', f'Select position of userpeak by clicking at the plot', btns)
+                        critical(self, '', f'Select position of userpeak by clicking on the spectrum plot. \n'
+                                 'Note: plot toolbar options, such as Pan and Zoom, must be turned off before selecting the position.', btns)
 
                     else:
                         try:

--- a/pyxrf/xanes_maps/tests/test_xanes_maps_api.py
+++ b/pyxrf/xanes_maps/tests/test_xanes_maps_api.py
@@ -274,8 +274,9 @@ def test_build_xanes_map_4(tmp_path):
 
 @pytest.mark.parametrize("kwargs", [{}, {"wd": None}, {"wd": "."},
                                     {"wd": "test_dir"},
-                                    {"wd": ("test_dir1","test_dir2")}])
+                                    {"wd": ("test_dir1", "test_dir2")}])
 def test_save_spectrum_as_csv_1(tmp_path, caplog, kwargs):
+    """Save data file, then read it and verify that the data match"""
 
     fln = "output.csv"
 
@@ -308,7 +309,7 @@ def test_save_spectrum_as_csv_1(tmp_path, caplog, kwargs):
     s = "\n".join([_ for _ in s.split("\n") if not _.strip().startswith("#")])
 
     dframe = pd.read_csv(StringIO(s))
-    assert  tuple(dframe.columns) == ("Incident Energy, keV", "XANES spectrum"), \
+    assert tuple(dframe.columns) == ("Incident Energy, keV", "XANES spectrum"), \
         f"Incorrect column labels: {tuple(dframe.columns)}"
 
     data = dframe.values
@@ -320,7 +321,7 @@ def test_save_spectrum_as_csv_1(tmp_path, caplog, kwargs):
 
 
 def test_save_spectrum_as_csv_2(tmp_path, caplog):
-    """Failing tests"""
+    """Failing cases"""
 
     fln = "output.csv"
     os.chdir(tmp_path)  # Make 'tmp_path' current directory
@@ -328,7 +329,6 @@ def test_save_spectrum_as_csv_2(tmp_path, caplog):
     n_pts = 50
     energy = np.random.rand(n_pts)
     spectrum = np.random.rand(n_pts)
-
 
     caplog.set_level(logging.INFO)
     _save_spectrum_as_csv(fln=fln, energy=None, spectrum=spectrum)

--- a/pyxrf/xanes_maps/tests/test_xanes_maps_api.py
+++ b/pyxrf/xanes_maps/tests/test_xanes_maps_api.py
@@ -2,11 +2,15 @@ import os
 import jsonschema
 import pytest
 import numpy as np
+import numpy.testing as npt
+from io import StringIO
+import logging
+import pandas as pd
 
 from pyxrf.xanes_maps.xanes_maps_api import (
     _build_xanes_map_api, _build_xanes_map_param_default, _build_xanes_map_param_schema,
     build_xanes_map, check_elines_activation_status, adjust_incident_beam_energies,
-    subtract_xanes_pre_edge_baseline)
+    subtract_xanes_pre_edge_baseline, _save_spectrum_as_csv)
 
 from pyxrf.core.yaml_param_files import (
     _parse_docstring_parameters, _verify_parsed_docstring,
@@ -266,3 +270,84 @@ def test_build_xanes_map_4(tmp_path):
 
     # Repeat the same operation with exceptions disabled. The operation should succeed.
     build_xanes_map(emission_line="Fe_K", parameter_file_path=file_path, xrf_subdir="")
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"wd": None}, {"wd": "."},
+                                    {"wd": "test_dir"},
+                                    {"wd": ("test_dir1","test_dir2")}])
+def test_save_spectrum_as_csv_1(tmp_path, caplog, kwargs):
+
+    fln = "output.csv"
+
+    os.chdir(tmp_path)  # Make 'tmp_path' current directory
+
+    fln_full = fln
+    if ("wd" in kwargs) and (kwargs["wd"] is not None):
+        if isinstance(kwargs["wd"], tuple):
+            kwargs["wd"] = os.path.join(*kwargs["wd"])
+        fln_full = os.path.join(kwargs["wd"], fln)
+    fln_full = os.path.abspath(fln_full)
+
+    n_pts = 50
+    energy = np.random.rand(n_pts)
+    spectrum = np.random.rand(n_pts)
+
+    caplog.set_level(logging.INFO)
+
+    # Save CSV file
+    _save_spectrum_as_csv(fln=fln, energy=energy, spectrum=spectrum, **kwargs)
+
+    assert f"Selected spectrum was saved to file '{fln_full}'" in str(caplog.text), \
+        "Incorrect reporting of the event of the correctly saved file"
+    caplog.clear()
+
+    # Now read the CSV file as a string
+    with open(fln_full, "r") as f:
+        s = f.read()
+    # Remove comments (lines that start with #, may contain spaces at the beginning of the string)
+    s = "\n".join([_ for _ in s.split("\n") if not _.strip().startswith("#")])
+
+    dframe = pd.read_csv(StringIO(s))
+    assert  tuple(dframe.columns) == ("Incident Energy, keV", "XANES spectrum"), \
+        f"Incorrect column labels: {tuple(dframe.columns)}"
+
+    data = dframe.values
+    energy2, spectrum2 = data[:, 0], data[:, 1]
+    npt.assert_array_almost_equal(energy, energy2,
+                                  err_msg="Recovered energy array is different from the original")
+    npt.assert_array_almost_equal(spectrum, spectrum2,
+                                  err_msg="Recovered spectrum array is different from the original")
+
+
+def test_save_spectrum_as_csv_2(tmp_path, caplog):
+    """Failing tests"""
+
+    fln = "output.csv"
+    os.chdir(tmp_path)  # Make 'tmp_path' current directory
+
+    n_pts = 50
+    energy = np.random.rand(n_pts)
+    spectrum = np.random.rand(n_pts)
+
+
+    caplog.set_level(logging.INFO)
+    _save_spectrum_as_csv(fln=fln, energy=None, spectrum=spectrum)
+    assert "The array 'energy' is None" in str(caplog.text)
+    caplog.clear()
+
+    _save_spectrum_as_csv(fln=fln, spectrum=spectrum)
+    assert "The array 'energy' is None" in str(caplog.text)
+    caplog.clear()
+
+    _save_spectrum_as_csv(fln=fln, energy=energy, spectrum=None)
+    assert "The array 'spectrum' is None" in str(caplog.text)
+    caplog.clear()
+
+    _save_spectrum_as_csv(fln=fln, energy=energy)
+    assert "The array 'spectrum' is None" in str(caplog.text)
+    caplog.clear()
+
+    spectrum = spectrum[:-1]
+    _save_spectrum_as_csv(fln=fln, energy=energy, spectrum=spectrum)
+    assert "Arrays 'energy' and 'spectrum' have different size:" in str(caplog.text)
+    caplog.clear()

--- a/pyxrf/xanes_maps/xanes_maps_api.py
+++ b/pyxrf/xanes_maps/xanes_maps_api.py
@@ -1855,7 +1855,14 @@ def _align_stacks(eline_data, eline_alignment, alignment_starts_from="top"):
 
     """Align stack of XRF maps for each element"""
     sr = StackReg(StackReg.TRANSLATION)
-    sr.register_stack(_flip_stack(eline_data[eline_alignment], alignment_starts_from),
+
+    # Normalize data used to compute matrix
+    data = np.array(eline_data[eline_alignment])
+    for n in range(data.shape[0]):
+        data[n, :, :] = data[n, :, :] / np.sum(data[n, :, :])
+    eline_data["ALIGN"] = np.array(data)  ###! (just for testing)
+
+    sr.register_stack(_flip_stack(data, alignment_starts_from),
                       reference="previous")
 
     eline_data_aligned = {}

--- a/pyxrf/xanes_maps/xanes_maps_api.py
+++ b/pyxrf/xanes_maps/xanes_maps_api.py
@@ -3058,10 +3058,20 @@ def _save_spectrum_as_csv(*, fln, wd=None, msg_info=None, energy=None, spectrum=
         The array of spectrum values. Must have the same size as 'energy'.
     """
 
-    # Full file path
-    file_path = os.path.join(wd, fln) if wd else fln
-
     try:
+        if wd:
+            # Full file path
+            wd = os.path.expanduser(wd)
+            file_path = os.path.join(wd, fln) if wd else fln
+            # Create directory (just in case it doesn't exist)
+            os.makedirs(wd, exist_ok=True)
+        else:
+            # 'wd' is not set, so write to current directory
+            file_path = fln
+
+        # Absolute path is more informative in the user input
+        file_path = os.path.abspath(file_path)
+
         # Verify that the arrays are valid and provide user-friendly message
         if energy is None:
             raise ValueError("The array 'energy' is None")
@@ -3108,8 +3118,8 @@ if __name__ == "__main__":
     build_xanes_map(start_id=92276, end_id=92335,
                     xrf_fitting_param_fln="param_335",
                     scaler_name="sclr1_ch4", wd=None,
-                    # sequence="process",
-                    sequence="build_xanes_map",
+                    sequence="process",
+                    # sequence="build_xanes_map",
                     alignment_starts_from="top",
                     ref_file_name="refs_Fe_P23.csv",
                     fitting_method="nnls",

--- a/pyxrf/xanes_maps/xanes_maps_api.py
+++ b/pyxrf/xanes_maps/xanes_maps_api.py
@@ -2372,7 +2372,7 @@ def show_image_stack(*, eline_data, energies, eline_selected,
             pt_x_max = x_max * self.pos_dx + self.pos_x_min
             pt_y_max = y_max * self.pos_dy + self.pos_y_min
             # This message will the placed in the first line of the csv file
-            msg_info = f"# Selection - x: {x_min} .. {x_max} ({pt_x_min:.5g} .. {pt_x_max:.5g})   "\
+            msg_info = f"Selection - x: {x_min} .. {x_max} ({pt_x_min:.5g} .. {pt_x_max:.5g})   "\
                        f"y: {y_min} .. {y_max} ({pt_y_min:.5g} .. {pt_y_max:.5g})"
 
             _save_spectrum_as_csv(fln=fln,
@@ -3050,7 +3050,6 @@ def _save_spectrum_as_csv(*, fln, wd=None, msg_info=None, energy=None, spectrum=
 
     msg_info: str
         A string that will be placed at the beginning of the CSV file before the file header.
-        Each line in the string must start with # (to separate the comment).
 
     energy: ndarray(float)
         The array of energy values in keV
@@ -3079,7 +3078,11 @@ def _save_spectrum_as_csv(*, fln, wd=None, msg_info=None, energy=None, spectrum=
         # Format as 'CSV'
         str = data.to_csv(index=False)
         # Attach the comment to the beginning of the formatted string
-        str = f"{msg_info}\n{str}"
+        #   If 'msg_info' is '' or None, then don't add the comment
+        if msg_info:
+            # Add '# ' at the beginning of each line
+            msg_info = "\n".join([f"# {_}" for _ in msg_info.split("\n")])
+            str = f"{msg_info}\n{str}"
         # Save to file
         with open(file_path, "w") as f:
             f.write(str)


### PR DESCRIPTION
The following features were implemented:

-- Allow using any map (not only maps of element emission lines) for alignment of stacks of maps. For example, maps of total count (total scattering) may provide better performance for some experiments. Now the parameter ``emission_line_alignment`` of ``build_xanes_maps`` may be set to a valid emission line (e.g. ``"Fe_K"``) or to the name of any existing map (e.g. ``"total_cnt"``).

-- Normalization of a map stack used a alignment reference. Normalization can be turned on and off by setting ``normalize_alignment_stack`` parameter of ``build_xanes_maps``.

-- Button is added to interactive XANES map browsing window (``build_xanes_map``) to save average XANES spectrum based on the selected area of the map.