### PR TITLE
Fixed the issue of Dask creating temporary directory in the current working directory.

### DIFF
--- a/pyxrf/api.py
+++ b/pyxrf/api.py
@@ -5,8 +5,7 @@ from .model.load_data_from_db import make_hdf, export1d  # noqa: F401
 from .model.command_tools import fit_pixel_data_and_save, pyxrf_batch  # noqa: F401
 from .xanes_maps.xanes_maps_api import build_xanes_map  # noqa: F401
 from .simulation.sim_xrf_scan_data import gen_hdf5_qa_dataset, gen_hdf5_qa_dataset_preset_1  # noqa: F401
-
-# from .model.command_tools import pyxrf_batch  # noqa: F401
+from .core.map_processing import dask_client_create  # noqa: F401
 
 # Note:  the statement '# noqa: F401' is telling flake8 to ignore violation F401 at the given line
 #     Violation F401 - the package is imported but unused
@@ -48,6 +47,9 @@ def pyxrf_api():
         Data processing:
           pyxrf_batch - batch processing of XRF maps
           build_xanes_map - generation and processing of XANES maps
+
+        Dask client:
+          dask_client_create - returns Dask client for use in batch scripts
 
         Simulation of datasets:
           gen_hdf5_qa_dataset - generate quantitative analysis dataset

--- a/pyxrf/core/map_processing.py
+++ b/pyxrf/core/map_processing.py
@@ -18,11 +18,25 @@ def dask_client_create(**kwargs):
     """
     Create Dask client object. The function is trivial and introduced so that
     Dask client is created in uniform way throughout the program.
+    The client is configured to keep temporary data in `~/.dask` directory
+    instead of the current directory.
+
+    Creating new Dask client may be costly (a few extra seconds). If computations require
+    multiple calls to functions that are running on Dask, overhead can be reduced by creating
+    one common Dask client and supplying the reference to the client as a parameter in each
+    function call.
+
+    .. code:: python
+
+        client = dask_client_create()  # Create Dask client
+        < code that runs computations >
+        client.close()  # Close Dask client
 
     Parameters
     ----------
     kwargs: dict, optional
-        kwargs will be passed to the Dask client constructor
+        kwargs will be passed to the Dask client constructor. No extra parameters are needed
+        in most cases.
 
     Returns
     -------
@@ -31,10 +45,12 @@ def dask_client_create(**kwargs):
     """
     _kwargs = {"processes": True, "silence_logs": logging.ERROR}
     _kwargs.update(kwargs)
-    client = Client(**_kwargs)
+
     dask.config.set(shuffle="disk")
     path_dask_data = os.path.expanduser("~/.dask")
     dask.config.set({"temporary_directory": path_dask_data})
+
+    client = Client(**_kwargs)
     return client
 
 

--- a/pyxrf/core/map_processing.py
+++ b/pyxrf/core/map_processing.py
@@ -29,7 +29,7 @@ def dask_client_create(**kwargs):
     .. code:: python
 
         client = dask_client_create()  # Create Dask client
-        < code that runs computations >
+        # <-- code that runs computations -->
         client.close()  # Close Dask client
 
     Parameters

--- a/pyxrf/model/command_tools.py
+++ b/pyxrf/model/command_tools.py
@@ -444,7 +444,14 @@ def pyxrf_batch(start_id=None, end_id=None, *, param_file_name, data_files=None,
         Dask client object. If None, then Dask client is created automatically.
         If a batch of files is processed, then creating Dask client and
         passing the reference to it to the processing functions will save
-        execution time: `client = Client(processes=True, silence_logs=logging.ERROR)`
+        execution time:
+
+        .. code:: python
+
+            from pyxrf.api import dask_client_create
+            client = dask_client_create()  # Create Dask client
+            # <-- code that runs computations -->
+            client.close()  # Close Dask client
 
     Returns
     -------

--- a/pyxrf/xanes_maps/xanes_maps_api.py
+++ b/pyxrf/xanes_maps/xanes_maps_api.py
@@ -328,7 +328,14 @@ def build_xanes_map(start_id=None, end_id=None, *, parameter_file_path=None,
         Dask client object. If None, then Dask client is created automatically.
         If a batch of files is processed, then creating Dask client and
         passing the reference to it to the processing functions will save
-        execution time: `client = Client(processes=True, silence_logs=logging.ERROR)`
+        execution time:
+
+        .. code:: python
+
+            from pyxrf.api import dask_client_create
+            client = dask_client_create()  # Create Dask client
+            # <-- code that runs computations -->
+            client.close()  # Close Dask client
 
     parameter_file_path : str
         absolute or relative path to the YAML file, which contains the processing parameters.


### PR DESCRIPTION
The default behavior of Dask is to create temporary directory `dask-worker-space` in the current working directory. The location of the temporary directory can be changed by configuring Dask. The desired location is `~/.dask`, which works on every OS if `~` is properly expanded.

The existing code was applying configuration after the client was created the first time in the application, so the temporary directories were still created. In the code for this PR, the order is changed so that Dask is always configured first, then the client is created. 

The tests were modified to verify that no temporary directory is created in the current directory.   