### PR TITLE
Consolidate storage and management of parameter and data.

### DIFF
--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -72,7 +72,6 @@ class GlobalProcessingClasses:
         self.io_model.observe('data', self.param_model.exp_data_update)
         self.io_model.observe('data', self.fit_model.exp_data_update)
         self.io_model.observe('data_all', self.fit_model.exp_data_all_update)
-        self.io_model.observe('data_sets', self.fit_model.data_sets_update)
 
         # send img dict to img_model for visualization
         self.io_model.observe('img_dict', self.setting_model.img_dict_update)
@@ -115,7 +114,6 @@ class GlobalProcessingClasses:
         def _update_data():
             self.plot_model.data_sets = self.io_model.data_sets
             self.setting_model.data_sets = self.io_model.data_sets
-            self.fit_model.data_sets = self.io_model.data_sets
             self.fit_model.fit_img = {}  # clear dict in fitmodel to rm old results
             # This will draw empty (hidden) preview plot, since no channels are selected.
             self.plot_model.update_preview_spectrum_plot()
@@ -197,7 +195,6 @@ class GlobalProcessingClasses:
         def _update_data():
             self.plot_model.data_sets = self.io_model.data_sets
             self.setting_model.data_sets = self.io_model.data_sets
-            self.fit_model.data_sets = self.io_model.data_sets
             self.fit_model.fit_img = {}  # clear dict in fitmodel to rm old results
             # This will draw empty (hidden) preview plot, since no channels are selected.
             self.plot_model.update_preview_spectrum_plot()

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -79,9 +79,6 @@ class GlobalProcessingClasses:
         self.io_model.observe('data_all', self.fit_model.exp_data_all_update)
         self.io_model.observe('data_sets', self.fit_model.data_sets_update)
 
-        # send fitting param of summed spectrum to param_model
-        self.io_model.observe('param_fit', self.param_model.param_from_db_update)
-
         # send img dict to img_model for visualization
         self.io_model.observe('img_dict', self.setting_model.img_dict_update)
         self.io_model.observe('img_dict', self.plot_model.img_dict_update)
@@ -1060,9 +1057,7 @@ class GlobalProcessingClasses:
         for key, val in param_dict.items():
             self.param_model.param_new[key] = val
 
-        element_list = self.param_model.element_list.copy()
-        self.param_model.create_spectrum_from_param_dict(self.param_model.param_new,
-                                                         element_list)
+        self.param_model.create_spectrum_from_param_dict()
         self.apply_to_fit()
 
     def get_quant_standard_list(self):

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -43,7 +43,7 @@ class GlobalProcessingClasses:
         """
         working_directory, default_parameters = self._get_defaults()
         self.param_model = ParamModel(default_parameters=default_parameters)
-        self.io_model = FileIOModel(working_directory=working_directory)
+        self.io_model = FileIOModel(param_model=self.param_model, working_directory=working_directory)
         self.plot_model = LinePlotModel(param_model=self.param_model)
         self.fit_model = Fit1D(param_model=self.param_model, io_model=self.io_model,
                                working_directory=working_directory, default_parameters=default_parameters)

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -44,7 +44,7 @@ class GlobalProcessingClasses:
         working_directory, default_parameters = self._get_defaults()
         self.param_model = ParamModel(default_parameters=default_parameters)
         self.io_model = FileIOModel(param_model=self.param_model, working_directory=working_directory)
-        self.plot_model = LinePlotModel(param_model=self.param_model)
+        self.plot_model = LinePlotModel(param_model=self.param_model, io_model=self.io_model)
         self.fit_model = Fit1D(param_model=self.param_model, io_model=self.io_model,
                                working_directory=working_directory)
         self.setting_model = SettingModel(param_model=self.param_model)

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -47,7 +47,7 @@ class GlobalProcessingClasses:
         self.plot_model = LinePlotModel(param_model=self.param_model, io_model=self.io_model)
         self.fit_model = Fit1D(param_model=self.param_model, io_model=self.io_model,
                                working_directory=working_directory)
-        self.setting_model = SettingModel(param_model=self.param_model)
+        self.setting_model = SettingModel(param_model=self.param_model, io_model=self.io_model)
         self.img_model_adv = DrawImageAdvanced()
         self.img_model_rgb = DrawImageRGB(img_model_adv=self.img_model_adv)
 
@@ -109,7 +109,6 @@ class GlobalProcessingClasses:
         self.io_model.working_directory = f_dir
 
         def _update_data():
-            self.setting_model.data_sets = self.io_model.data_sets
             self.fit_model.fit_img = {}  # clear dict in fitmodel to rm old results
             # This will draw empty (hidden) preview plot, since no channels are selected.
             self.plot_model.update_preview_spectrum_plot()
@@ -189,7 +188,6 @@ class GlobalProcessingClasses:
         self.io_model.data_ready = False
 
         def _update_data():
-            self.setting_model.data_sets = self.io_model.data_sets
             self.fit_model.fit_img = {}  # clear dict in fitmodel to rm old results
             # This will draw empty (hidden) preview plot, since no channels are selected.
             self.plot_model.update_preview_spectrum_plot()

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -47,7 +47,7 @@ class GlobalProcessingClasses:
         self.plot_model = LinePlotModel(param_model=self.param_model)
         self.fit_model = Fit1D(param_model=self.param_model, io_model=self.io_model,
                                working_directory=working_directory)
-        self.setting_model = SettingModel(default_parameters=default_parameters)
+        self.setting_model = SettingModel(param_model=self.param_model)
         self.img_model_adv = DrawImageAdvanced()
         self.img_model_rgb = DrawImageRGB(img_model_adv=self.img_model_adv)
 
@@ -115,7 +115,6 @@ class GlobalProcessingClasses:
         def _update_data():
             self.plot_model.parameters = self.param_model.param_new
             self.plot_model.data_sets = self.io_model.data_sets
-            self.setting_model.parameters = self.param_model.param_new
             self.setting_model.data_sets = self.io_model.data_sets
             self.fit_model.data_sets = self.io_model.data_sets
             self.fit_model.fit_img = {}  # clear dict in fitmodel to rm old results
@@ -199,7 +198,6 @@ class GlobalProcessingClasses:
         def _update_data():
             self.plot_model.parameters = self.param_model.param_new
             self.plot_model.data_sets = self.io_model.data_sets
-            self.setting_model.parameters = self.param_model.param_new
             self.setting_model.data_sets = self.io_model.data_sets
             self.fit_model.data_sets = self.io_model.data_sets
             self.fit_model.fit_img = {}  # clear dict in fitmodel to rm old results
@@ -1176,9 +1174,6 @@ class GlobalProcessingClasses:
             self.plot_model.plot_exp_opt = False
             self.plot_model.plot_exp_opt = True
 
-            # update params for roi sum
-            self.setting_model.update_parameter(self.param_model.param_new)
-
             # calculate profile and plot
             self.fit_model.get_profile()
 
@@ -1201,9 +1196,6 @@ class GlobalProcessingClasses:
             # update parameter for fit
             # self.param_model.create_full_param()
             self.fit_model.apply_default_param()
-
-            # update params for roi sum
-            self.setting_model.update_parameter(self.param_model.param_new)
 
             # Update displayed intensity of the selected peak
             self.plot_model.compute_manual_peak_intensity()
@@ -1514,43 +1506,8 @@ class GlobalProcessingClasses:
         self.param_model.create_full_param()  # Not sure this is needed
         self.fit_model.apply_default_param()
 
-        # update params for roi sum
-        self.setting_model.update_parameter(self.param_model.param_new)
-
         # Update displayed intensity of the selected peak
         self.plot_model.compute_manual_peak_intensity()
-
-    '''
-    def calculate_spectrum_helper(self):
-        """
-        Calculate spectrum, and update plotting and param_model.
-        Note: this is an original function from 'fit.enaml' file.
-        """
-        if self.fit_model.x0 is None or self.fit_model.y0 is None:
-            return
-
-        self.fit_model.get_profile()
-
-        # update experimental plot with new calibration values
-        self.plot_model.parameters = self.fit_model.param_dict
-        self.plot_model.plot_experiment()
-
-        self.plot_model.plot_fit(self.fit_model.cal_x, self.fit_model.cal_y,
-                                 self.fit_model.cal_spectrum,
-                                 self.fit_model.residual)
-
-        # For plotting purposes, otherwise plot will not update
-        self.plot_model.show_fit_opt = False
-        self.plot_model.show_fit_opt = True
-
-        # update autofit param
-        self.param_model.update_new_param(self.fit_model.param_dict)
-        self.param_model.update_name_list()
-        self.param_model.EC.turn_on_all()
-
-        # update params for roi sum
-        self.setting_model.update_parameter(self.fit_model.param_dict)
-    '''
 
     def total_spectrum_fitting(self):
 
@@ -1581,9 +1538,6 @@ class GlobalProcessingClasses:
         # param_model.get_new_param_from_file(parameter_file_path)
         self.param_model.update_name_list()
         self.param_model.EC.turn_on_all()
-
-        # update params for roi sum
-        self.setting_model.update_parameter(self.param_model.param_new)
 
         # Update displayed intensity of the selected peak
         self.plot_model.compute_manual_peak_intensity()

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -69,7 +69,6 @@ class GlobalProcessingClasses:
 
         # send exp data to different models
         self.io_model.observe('data', self.plot_model.exp_data_update)
-        self.io_model.observe('data', self.fit_model.exp_data_update)
         self.io_model.observe('data_all', self.fit_model.exp_data_all_update)
 
         # send img dict to img_model for visualization

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -42,8 +42,8 @@ class GlobalProcessingClasses:
         Run the sequence of actions needed to initialize PyXRF modules.
         """
         working_directory, default_parameters = self._get_defaults()
-        self.param_model = ParamModel(default_parameters=default_parameters)
-        self.io_model = FileIOModel(param_model=self.param_model, working_directory=working_directory)
+        self.io_model = FileIOModel(working_directory=working_directory)
+        self.param_model = ParamModel(default_parameters=default_parameters, io_model=self.io_model)
         self.plot_model = LinePlotModel(param_model=self.param_model, io_model=self.io_model)
         self.fit_model = Fit1D(param_model=self.param_model, io_model=self.io_model,
                                working_directory=working_directory)
@@ -69,7 +69,6 @@ class GlobalProcessingClasses:
 
         # send exp data to different models
         self.io_model.observe('data', self.plot_model.exp_data_update)
-        self.io_model.observe('data', self.param_model.exp_data_update)
         self.io_model.observe('data', self.fit_model.exp_data_update)
         self.io_model.observe('data_all', self.fit_model.exp_data_all_update)
 

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -113,7 +113,6 @@ class GlobalProcessingClasses:
         self.io_model.working_directory = f_dir
 
         def _update_data():
-            self.plot_model.parameters = self.param_model.param_new
             self.plot_model.data_sets = self.io_model.data_sets
             self.setting_model.data_sets = self.io_model.data_sets
             self.fit_model.data_sets = self.io_model.data_sets
@@ -196,7 +195,6 @@ class GlobalProcessingClasses:
         self.io_model.data_ready = False
 
         def _update_data():
-            self.plot_model.parameters = self.param_model.param_new
             self.plot_model.data_sets = self.io_model.data_sets
             self.setting_model.data_sets = self.io_model.data_sets
             self.fit_model.data_sets = self.io_model.data_sets
@@ -1094,7 +1092,6 @@ class GlobalProcessingClasses:
         self.fit_model.apply_default_param()
 
         # update experimental plots in case the coefficients change
-        self.plot_model.parameters = self.param_model.param_new
         self.plot_model.plot_experiment()
 
         self.plot_model.plot_fit(self.param_model.prefit_x,
@@ -1169,7 +1166,6 @@ class GlobalProcessingClasses:
             self.fit_model.apply_default_param()
 
             # update experimental plots
-            self.plot_model.parameters = self.param_model.param_new
             self.plot_model.plot_experiment()
             self.plot_model.plot_exp_opt = False
             self.plot_model.plot_exp_opt = True
@@ -1485,7 +1481,6 @@ class GlobalProcessingClasses:
         self.param_model.data_for_plot()
 
         # update experimental plots in case the coefficients change
-        self.plot_model.parameters = self.param_model.param_new
         self.plot_model.plot_experiment()
 
         self.plot_model.plot_fit(self.param_model.prefit_x,
@@ -1520,7 +1515,6 @@ class GlobalProcessingClasses:
         self.fit_model.get_profile()
 
         # update experimental plot with new calibration values
-        self.plot_model.parameters = self.param_model.param_new
         self.plot_model.plot_experiment()
 
         self.plot_model.plot_fit(self.fit_model.cal_x, self.fit_model.cal_y,

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -5,7 +5,7 @@ import copy
 import math
 from ..model.fileio import FileIOModel
 from ..model.lineplot import LinePlotModel
-from ..model.guessparam import GuessParamModel, save_as, fit_strategy_list, bound_options
+from ..model.parameters import ParamModel, save_as, fit_strategy_list, bound_options
 from ..model.draw_image import DrawImageAdvanced
 from ..model.draw_image_rgb import DrawImageRGB
 from ..model.fit_spectrum import Fit1D, get_cs
@@ -49,7 +49,7 @@ class GlobalProcessingClasses:
 
         defaults = self._get_defaults()
         self.io_model = FileIOModel(**defaults)
-        self.param_model = GuessParamModel(**defaults)
+        self.param_model = ParamModel(**defaults)
         self.plot_model = LinePlotModel(param_model=self.param_model)
         self.fit_model = Fit1D(param_model=self.param_model, io_model=self.io_model, **defaults)
         self.setting_model = SettingModel(**defaults)

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -31,28 +31,23 @@ class GlobalProcessingClasses:
         self.img_model_rgb = None
 
     def _get_defaults(self):
-
         # Set working directory to current working directory (if PyXRF is started from shell)
         working_directory = os.getcwd()
         logger.info(f"Starting PyXRF in the current working directory '{working_directory}'")
-
         default_parameters = param_data
-        defaults = {'working_directory': working_directory,
-                    'default_parameters': default_parameters}
-        return defaults
+        return working_directory, default_parameters
 
     def initialize(self):
         """
         Run the sequence of actions needed to initialize PyXRF modules.
-
         """
-
-        defaults = self._get_defaults()
-        self.io_model = FileIOModel(**defaults)
-        self.param_model = ParamModel(**defaults)
+        working_directory, default_parameters = self._get_defaults()
+        self.param_model = ParamModel(default_parameters=default_parameters)
+        self.io_model = FileIOModel(working_directory=working_directory)
         self.plot_model = LinePlotModel(param_model=self.param_model)
-        self.fit_model = Fit1D(param_model=self.param_model, io_model=self.io_model, **defaults)
-        self.setting_model = SettingModel(**defaults)
+        self.fit_model = Fit1D(param_model=self.param_model, io_model=self.io_model,
+                               working_directory=working_directory, default_parameters=default_parameters)
+        self.setting_model = SettingModel(default_parameters=default_parameters)
         self.img_model_adv = DrawImageAdvanced()
         self.img_model_rgb = DrawImageRGB(img_model_adv=self.img_model_adv)
 
@@ -1057,7 +1052,7 @@ class GlobalProcessingClasses:
         for key, val in param_dict.items():
             self.param_model.param_new[key] = val
 
-        self.param_model.create_spectrum_from_param_dict()
+        self.param_model.create_spectrum_from_param_dict(reset=False)
         self.apply_to_fit()
 
     def get_quant_standard_list(self):

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -67,9 +67,8 @@ class GlobalProcessingClasses:
         self.io_model.observe('file_name', self.setting_model.filename_update)
         self.io_model.observe('runid', self.fit_model.runid_update)
 
-        # send exp data to different models
+        # Perform updates when 'io_model.data' is changed (no data is passed)
         self.io_model.observe('data', self.plot_model.exp_data_update)
-        self.io_model.observe('data_all', self.fit_model.exp_data_all_update)
 
         # send img dict to img_model for visualization
         self.io_model.observe('img_dict', self.setting_model.img_dict_update)
@@ -110,7 +109,6 @@ class GlobalProcessingClasses:
         self.io_model.working_directory = f_dir
 
         def _update_data():
-            self.plot_model.data_sets = self.io_model.data_sets
             self.setting_model.data_sets = self.io_model.data_sets
             self.fit_model.fit_img = {}  # clear dict in fitmodel to rm old results
             # This will draw empty (hidden) preview plot, since no channels are selected.
@@ -191,7 +189,6 @@ class GlobalProcessingClasses:
         self.io_model.data_ready = False
 
         def _update_data():
-            self.plot_model.data_sets = self.io_model.data_sets
             self.setting_model.data_sets = self.io_model.data_sets
             self.fit_model.fit_img = {}  # clear dict in fitmodel to rm old results
             # This will draw empty (hidden) preview plot, since no channels are selected.
@@ -250,7 +247,6 @@ class GlobalProcessingClasses:
         """
         self.io_model.data_sets[dset_name].selected_for_preview = True if is_visible else False
         self.io_model.update_data_set_buffers()
-        self.plot_model.data_sets = self.io_model.data_sets
         self.plot_model.update_preview_spectrum_plot()
         self.plot_model.update_total_count_map_preview()
 
@@ -414,7 +410,6 @@ class GlobalProcessingClasses:
 
     def apply_mask_to_datasets(self):
         self.io_model.apply_mask_to_datasets()
-        self.plot_model.data_sets = self.io_model.data_sets
         self.plot_model.update_preview_spectrum_plot()
 
     # ==========================================================================

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -590,9 +590,9 @@ class DataSelection(Atom):
     both are set.
 
     There are some unresolved questions about logic:
-    - what is exactly the role of `self.data`? It is definitely used when
+    - what is exactly the role of `self.io_model.data`? It is definitely used when
     the data is plotted, but is it ever bypassed by directly calling `get_sum`?
-    If the data is always accessed using `self.data`, then storing the averaged
+    If the data is always accessed using `self.io_model.data`, then storing the averaged
     spectrum in cache is redundant, but since the array is small, it's not
     much overhead to keep another copy just in case.
     - there is no obvious way to set `point1` and `point2`

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -118,8 +118,8 @@ class FileIOModel(Atom):
     #   its value should not be used for computations!!!
     incident_energy_set = Float(0.0)
 
-    def __init__(self, **kwargs):
-        self.working_directory = kwargs['working_directory']
+    def __init__(self, *, working_directory):
+        self.working_directory = working_directory
         self.mask_data = None
 
         # Display PyXRF version in the window title

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -60,9 +60,6 @@ class FileIOModel(Atom):
     img_dict : dict
         Dict of 2D arrays, such as 2D roi pv or fitted data
     """
-    # Reference to ParamModel object
-    param_model = Typed(object)
-
     window_title = Str()
     window_title_base = Str()
 
@@ -121,8 +118,7 @@ class FileIOModel(Atom):
     #   its value should not be used for computations!!!
     incident_energy_set = Float(0.0)
 
-    def __init__(self, *, param_model, working_directory):
-        self.param_model = param_model
+    def __init__(self, *, working_directory):
         self.working_directory = working_directory
         self.mask_data = None
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -60,6 +60,9 @@ class FileIOModel(Atom):
     img_dict : dict
         Dict of 2D arrays, such as 2D roi pv or fitted data
     """
+    # Reference to ParamModel object
+    param_model = Typed(object)
+
     window_title = Str()
     window_title_base = Str()
 
@@ -118,7 +121,8 @@ class FileIOModel(Atom):
     #   its value should not be used for computations!!!
     incident_energy_set = Float(0.0)
 
-    def __init__(self, *, working_directory):
+    def __init__(self, *, param_model, working_directory):
+        self.param_model = param_model
         self.working_directory = working_directory
         self.mask_data = None
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -70,7 +70,6 @@ class FileIOModel(Atom):
     load_status = Str()
     data_sets = Typed(OrderedDict)
     img_dict = Dict()
-    param_fit = Dict()
     file_channel_list = List()
 
     runid = Int(-1)  # Run ID of the current run
@@ -390,20 +389,6 @@ class FileIOModel(Atom):
 
         requires databroker
         """
-        # if self.h_num != 0 and self.v_num != 0:
-        #     datashape = [self.v_num, self.h_num]
-
-        #  one way to cache data is to save as h5 file, to be considered later
-        # tmp_wd = '~/.tmp/'
-        # if not os.path.exists(tmp_wd):
-        #     os.makedirs(tmp_wd)
-        # fpath = os.path.join(tmp_wd, self.fname_from_db)
-        # if not os.path.exists(fpath):
-        #     make_hdf(self.runid, fname=fpath)
-        # self.img_dict, self.data_sets = file_handler(tmp_wd,
-        #                                             self.fname_from_db,
-        #                                             load_each_channel=self.load_each_channel)
-
         # Clear data. If reading the file fails, then old data should not be kept.
         self.file_channel_list = []
         self.clear()
@@ -442,21 +427,6 @@ class FileIOModel(Atom):
                     f"'{detector_name}' was loaded successfully.")
 
         self.file_channel_list = list(self.data_sets.keys())
-
-        # Disable loading from 'analysis store' for now (because there is no 'analysis store')
-        # ----------------------------------------------------------------
-        # # Load results from the analysis store
-        # from .data_to_analysis_store import get_analysis_result
-        # hdr = get_analysis_result(self.runid)
-        # if hdr is not None:
-        #     d1 = hdr.table(stream_name='primary')
-        #     # d2 = hdr.table(stream_name='spectrum')
-        #     self.param_fit = hdr.start.processor_parameters
-        #     # self.data = d2['summed_spectrum_experiment']
-        #     fit_result = {k: v for k, v in zip(d1['element_name'], d1['map'])}
-        #     # tmp = {k: v for k, v in self.img_dict.items()}
-        #     img_dict['scan2D_{}_fit'.format(self.runid)] = fit_result
-        # ----------------------------------------------------------------
 
         self.img_dict = img_dict
 

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -65,10 +65,8 @@ class Fit1D(Atom):
     file_status = Str()
 
     img_dict = Dict()
-    data_sets = Typed(OrderedDict)
 
     element_list = List()
-    data_sets = Dict()
     data_all = Typed(object)
     data = Typed(np.ndarray)
     fit_x = Typed(np.ndarray)
@@ -258,13 +256,6 @@ class Fit1D(Atom):
         _key = [k for k in self.img_dict.keys() if 'scaler' in k]
         if len(_key) != 0:
             self.scaler_keys = sorted(self.img_dict[_key[0]].keys())
-
-    def data_sets_update(self, change):
-        """
-        Observer function to be connected to the fileio model
-        in the top-level gui.py startup
-        """
-        self.data_sets = change['value']
 
     def scaler_index_update(self, change):
         """

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -158,7 +158,7 @@ class Fit1D(Atom):
     scaler_keys = List()
     scaler_index = Int(0)
 
-    # Reference to GuessParamModel object
+    # Reference to ParamModel object
     param_model = Typed(object)
 
     # Reference to FileIOMOdel
@@ -189,7 +189,7 @@ class Fit1D(Atom):
         self.param_dict = copy.deepcopy(self.default_parameters)
         self.all_strategy = OrderedDict()
 
-        # Reference to GuessParamModel object
+        # Reference to ParamModel object
         self.param_model = param_model
 
         # Reference to FileIOMOdel
@@ -301,7 +301,7 @@ class Fit1D(Atom):
 
     def energy_bound_high_update(self, change):
         """
-        Observer function that connects 'param_model' (GuessParamModel)
+        Observer function that connects 'param_model' (ParamModel)
         attribute 'energy_bound_high_buf' with the respective
         value in 'self.param_dict'
         """
@@ -309,7 +309,7 @@ class Fit1D(Atom):
 
     def energy_bound_low_update(self, change):
         """
-        Observer function that connects 'param_model' (GuessParamModel)
+        Observer function that connects 'param_model' (ParamModel)
         attribute 'energy_bound_low_buf' with the respective
         value in 'self.param_dict'
         """

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -1092,39 +1092,6 @@ class Fit1D(Atom):
                 temp_dict[e] = ps
         self.EC.add_to_dict(temp_dict)
 
-    # def manual_input(self):
-    #     #default_area = 1e2
-    #     ps = PreFitStatus(z=get_Z(self.e_name),
-    #                       energy=get_energy(self.e_name),
-    #                       #area=area_dict[self.e_name]*ratio_v,
-    #                       #spectrum=data_out[self.e_name]*ratio_v,
-    #                       #maxv=self.add_element_intensity,
-    #                       norm=1)
-    #                       #lbd_stat=False)
-    #
-    #     self.EC.add_to_dict({self.e_name: ps})
-    #     logger.info('')
-    #     self.update_name_list()
-
-    # def add_pileup(self):
-    #     if self.pileup_data['intensity'] > 0:
-    #         e_name = (self.pileup_data['element1'] + '-'
-    #                   + self.pileup_data['element2'])
-    #
-    #         energy = str(float(get_energy(self.pileup_data['element1']))
-    #                      + float(get_energy(self.pileup_data['element2'])))
-    #
-    #         ps = PreFitStatus(z=get_Z(e_name),
-    #                           energy=energy,
-    #                           #area=area_dict[e_name]*ratio_v,
-    #                           #spectrum=data_out[e_name]*ratio_v,
-    #                           #maxv=self.pileup_data['intensity'],
-    #                           norm=1)
-    #                           #lbd_stat=False)
-    #         logger.info('{} peak is added'.format(e_name))
-    #     self.EC.add_to_dict({e_name: ps})
-    #     self.update_name_list()
-
 
 def combine_lines(components, element_list, background):
     """

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -148,7 +148,6 @@ class Fit1D(Atom):
     pixel_fit_info = Str()
 
     pixel_fit_method = Int(0)
-    param_q = Typed(object)
 
     result_map = Dict()
     map_interpolation = Bool(False)
@@ -188,7 +187,6 @@ class Fit1D(Atom):
         self.result_folder = kwargs['working_directory']
         self.default_parameters = kwargs['default_parameters']
         self.param_dict = copy.deepcopy(self.default_parameters)
-        self.param_q = deque()
         self.all_strategy = OrderedDict()
 
         # Reference to GuessParamModel object
@@ -382,12 +380,6 @@ class Fit1D(Atom):
         else:
             raise Exception(f"Line '{eline_name}' is not in the list of selected element lines.")
 
-    def keep_size(self):
-        """Keep the size of deque as 2.
-        """
-        while len(self.param_q) > 2:
-            self.param_q.popleft()
-
     def read_param_from_file(self, param_path):
         """
         Update parameters if new param_path is given.
@@ -400,10 +392,6 @@ class Fit1D(Atom):
         with open(param_path, 'r') as json_data:
             self.default_parameters = json.load(json_data)
 
-        #  use queue to save the status of parameters
-        self.param_q.append(copy.deepcopy(self.default_parameters))
-        self.keep_size()
-
     def update_default_param(self, param):
         """assigan new values to default param.
 
@@ -412,9 +400,6 @@ class Fit1D(Atom):
         param : dict
         """
         self.default_parameters = copy.deepcopy(param)
-        #  use queue to save the status of parameters
-        self.param_q.append(copy.deepcopy(self.default_parameters))
-        self.keep_size()
 
     def apply_default_param(self):
         """
@@ -689,9 +674,6 @@ class Fit1D(Atom):
         self.assign_fitting_result()
         self.fit_info = 'Summed spectrum fitting is done!'
         logger.info('-------- ' + self.fit_info + ' --------')
-
-        self.param_q.append(copy.deepcopy(self.param_dict))
-        self.keep_size()
 
     def compute_current_rfactor(self, save_fit=True):
         """

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -28,7 +28,7 @@ from skbeam.core.fitting.xrf_model import (ModelSpectrum, update_parameter_dict,
                                            # linear_spectrum_fitting,
                                            register_strategy, TRANSITIONS_LOOKUP)
 from skbeam.fluorescence import XrfElement as Element
-from .guessparam import (calculate_profile, fit_strategy_list,
+from .parameters import (calculate_profile, fit_strategy_list,
                          trim_escape_peak, define_range, get_energy,
                          get_Z, PreFitStatus, ElementController,
                          update_param_from_element)

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -67,8 +67,6 @@ class Fit1D(Atom):
     img_dict = Dict()
 
     element_list = List()
-    data_all = Typed(object)
-    # data = Typed(np.ndarray)
     fit_x = Typed(np.ndarray)
     fit_y = Typed(np.ndarray)
     residual = Typed(np.ndarray)
@@ -390,19 +388,6 @@ class Fit1D(Atom):
         #  define element_adjust as fixed
         # self.param_dict = define_param_bound_type(self.param_dict)
 
-    def exp_data_all_update(self, change):
-        """
-        Observer function to be connected to the fileio model
-        in the top-level gui.py startup
-
-        Parameters
-        ----------
-        changed : dict
-            This is the dictionary that gets passed to a function
-            with the @observe decorator
-        """
-        self.data_all = change['value']
-
     def filename_update(self, change):
         """
         Observer function to be connected to the fileio model
@@ -686,7 +671,7 @@ class Fit1D(Atom):
 
         # app.processEvents()
         self.result_map, calculation_info = single_pixel_fitting_controller(
-            self.data_all,
+            self.io_model.data_all,
             self.param_model.param_new,
             method=pixel_fit,
             pixel_bin=pixel_bin,
@@ -811,7 +796,7 @@ class Fit1D(Atom):
             high = int(self.roi_sum_opt['high']*100)
             logger.info('ROI sum at range ({}, {})'.format(self.roi_sum_opt['low'],
                                                            self.roi_sum_opt['high']))
-            sumv = np.sum(self.data_all[:, :, low:high], axis=2)
+            sumv = np.sum(self.io_model.data_all[:, :, low:high], axis=2)
             self.result_map['ROI'] = sumv
             # save to hdf again, this is not optimal
             self.save2Dmap_to_hdf()

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -6,7 +6,7 @@ import copy
 import os
 import re
 import math
-from collections import OrderedDict, deque
+from collections import OrderedDict
 import multiprocessing
 import multiprocessing.pool
 import h5py

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -182,10 +182,10 @@ class Fit1D(Atom):
     # *** The fields are not guaranteed to have valid values at any other time. ***
     qe_standard_distance_to_sample = Float(0.0)
 
-    def __init__(self, param_model, io_model, *args, **kwargs):
-        self.working_directory = kwargs['working_directory']
-        self.result_folder = kwargs['working_directory']
-        self.default_parameters = kwargs['default_parameters']
+    def __init__(self, param_model, io_model, *, working_directory, default_parameters):
+        self.working_directory = working_directory
+        self.result_folder = working_directory
+        self.default_parameters = default_parameters
         self.param_dict = copy.deepcopy(self.default_parameters)
         self.all_strategy = OrderedDict()
 

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -10,7 +10,6 @@ from matplotlib.lines import Line2D
 from matplotlib.collections import BrokenBarHCollection
 import matplotlib.ticker as mticker
 from matplotlib.colors import LogNorm
-from collections import OrderedDict
 from enum import Enum
 from mpl_toolkits.axes_grid1 import ImageGrid
 
@@ -171,7 +170,6 @@ class LinePlotModel(Atom):
     t_bar = Typed(object)
 
     plot_exp_list = List()
-    data_sets = Typed(OrderedDict)
 
     auto_fit_obj = List()
     show_autofit_opt = Bool()
@@ -744,7 +742,7 @@ class LinePlotModel(Atom):
 
         self.max_v = 1.0
         m = 0
-        for (k, v) in self.data_sets.items():
+        for (k, v) in self.io_model.data_sets.items():
             if v.selected_for_preview:
 
                 data_arr = np.asarray(v.data)
@@ -1398,7 +1396,7 @@ class LinePlotModel(Atom):
             Limit search to the datasets that are going to be displayed
         """
         max_size = 0
-        for dset in self.data_sets.values():
+        for dset in self.io_model.data_sets.values():
             if not only_displayed or dset.selected_for_preview:
                 # Raw data shape: (n_rows, n_columns, n_energy_bins)
                 max_size = max(max_size, dset.get_raw_data_shape()[2])
@@ -1494,7 +1492,7 @@ class LinePlotModel(Atom):
             n_range_low, n_range_high = 0, n_dset_points
 
         # All available datasets, we will print only the selected datasets
-        dset_names = list(self.data_sets.keys())
+        dset_names = list(self.io_model.data_sets.keys())
 
         if p_type == PlotTypes.LINLOG:
             top_margin_coef = 2.0
@@ -1509,7 +1507,7 @@ class LinePlotModel(Atom):
         self.min_e_preview = 1000.0  # Start with some large number
         self.max_e_preview = 0.1  # Start with some small number
         for n_line, dset_name in enumerate(dset_names):
-            dset = self.data_sets[dset_name]
+            dset = self.io_model.data_sets[dset_name]
 
             # Select color (even if the dataset is not displayed). This is done in order
             #   to ensure that each dataset is assigned the unique color.
@@ -1581,8 +1579,8 @@ class LinePlotModel(Atom):
         """
         # Find out if any data is selected
         show_plot = False
-        if self.data_sets:
-            show_plot = any([_.selected_for_preview for _ in self.data_sets.values()])
+        if self.io_model.data_sets:
+            show_plot = any([_.selected_for_preview for _ in self.io_model.data_sets.values()])
         logger.debug(f"LinePlotModel.update_preview_spectrum_plot(): show_plot={show_plot} hide={hide}")
         if show_plot and not hide:
             logger.debug("LinePlotModel.update_preview_spectrum_plot(): plotting existing datasets")
@@ -1604,7 +1602,7 @@ class LinePlotModel(Atom):
 
     def get_selected_datasets(self):
         """Returns the datasets selected for preview"""
-        return {k: v for (k, v) in self.data_sets.items() if v.selected_for_preview}
+        return {k: v for (k, v) in self.io_model.data_sets.items() if v.selected_for_preview}
 
     def _compute_map_preview_range(self, img_dict, key_list):
         range_min, range_max = None, None
@@ -1909,8 +1907,8 @@ class LinePlotModel(Atom):
 
         # Find out if any data is selected
         show_plot = False
-        if self.data_sets:
-            show_plot = any([_.selected_for_preview for _ in self.data_sets.values()])
+        if self.io_model.data_sets:
+            show_plot = any([_.selected_for_preview for _ in self.io_model.data_sets.values()])
         logger.debug(f"LinePlotModel.update_total_count_map_preview(): show_plot={show_plot} hide={hide}")
         if show_plot and not hide:
             logger.debug("LinePlotModel.update_total_count_map_preview(): plotting existing datasets")

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -100,7 +100,7 @@ class LinePlotModel(Atom):
     incident_energy : float
         in KeV
     param_model : Typed(object)
-        Reference to GuessParamModel object
+        Reference to ParamModel object
     """
     data = Typed(object)  # Typed(np.ndarray)
     exp_data_label = Str('experiment')
@@ -201,7 +201,7 @@ class LinePlotModel(Atom):
     img_dict = Dict()
     # roi_result = Dict()
 
-    # Reference to GuessParamModel object
+    # Reference to ParamModel object
     param_model = Typed(object)
 
     # Location of the vertical (mouse-selected) marker on the plot.
@@ -215,7 +215,7 @@ class LinePlotModel(Atom):
 
     def __init__(self, param_model):
 
-        # Reference to GuessParamModel object
+        # Reference to ParamModel object
         self.param_model = param_model
 
         self.data = None

--- a/pyxrf/model/parameters.py
+++ b/pyxrf/model/parameters.py
@@ -334,7 +334,7 @@ class ParamModel(Atom):
         reset : boolean
             reset (``True``) or clear (``False``) selection status of the element lines.
         """
-        self.param_new = copy.deepcopy(param)
+        self.param_new = param
         self.create_spectrum_from_param_dict(reset=reset)
 
     def exp_data_update(self, change):
@@ -382,6 +382,7 @@ class ParamModel(Atom):
         param_dict = self.param_new
         self.element_list = get_element_list(param_dict)
 
+        self.define_range()
         self.prefit_x, pre_dict, area_dict = calculate_profile(self.x0,
                                                                self.y0,
                                                                param_dict,
@@ -455,7 +456,6 @@ class ParamModel(Atom):
             element_status = {_: self.EC.element_dict[_].status for _ in self.EC.element_dict}
 
         self.EC.delete_all()
-        self.define_range()
         self.EC.add_to_dict(temp_dict)
 
         if not reset:
@@ -962,6 +962,19 @@ class ParamModel(Atom):
         names_other.sort()
 
         return names_elines + names_userpeaks + names_pileup_peaks + names_other
+
+    def read_param_from_file(self, param_path):
+        """
+        Update parameters if new param_path is given.
+
+        Parameters
+        ----------
+        param_path : str
+            path to save the file
+        """
+        with open(param_path, 'r') as json_data:
+            param = json.load(json_data)
+            self.update_new_param(param, reset=True)
 
     def find_peak(self, *, threshv=0.1, elemental_lines=None):
         """

--- a/pyxrf/model/parameters.py
+++ b/pyxrf/model/parameters.py
@@ -1005,8 +1005,8 @@ class ParamModel(Atom):
 
     def create_full_param(self):
         """
-        Extend the param to full param dict including each element's
-        information, and assign initial values from pre fit.
+        Update current ``self.param_new`` with elements from ``self.EC`` (delete elements that
+        are not in ``self.EC`` and update the existing elements.
         """
         self.define_range()
         # We set 'self.element_list' from 'EC' (because we want to set elements of 'self.param_new'

--- a/pyxrf/model/parameters.py
+++ b/pyxrf/model/parameters.py
@@ -319,7 +319,7 @@ class ParamModel(Atom):
         """
         with open(param_path, 'r') as json_data:
             self.param_new = json.load(json_data)
-        self.create_spectrum_from_param_dict()
+        self.create_spectrum_from_param_dict(reset=True)
         logger.info('Elements read from file are: {}'.format(self.element_list))
 
     def update_new_param(self, param, reset=True):
@@ -405,7 +405,7 @@ class ParamModel(Atom):
                 ps = PreFitStatus(z=get_Z(e), energy=get_energy(e),
                                   area=float(area), spectrum=spectrum,
                                   maxv=float(np.around(np.max(spectrum), self.max_area_dig)),
-                                  norm=-1, lbd_stat=False)
+                                  norm=-1, status=True, lbd_stat=False)
                 temp_dict[e] = ps
 
             elif '-' in e:  # pileup peaks
@@ -417,7 +417,7 @@ class ParamModel(Atom):
                 ps = PreFitStatus(z=get_Z(e), energy=str(energy),
                                   area=area, spectrum=spectrum,
                                   maxv=np.around(np.max(spectrum), self.max_area_dig),
-                                  norm=-1, lbd_stat=False)
+                                  norm=-1, status=True, lbd_stat=False)
                 temp_dict[e] = ps
 
             else:
@@ -447,7 +447,7 @@ class ParamModel(Atom):
                     ps = PreFitStatus(z=get_Z(ename), energy=energy,
                                       area=area, spectrum=spectrum,
                                       maxv=np.around(np.max(spectrum), self.max_area_dig),
-                                      norm=-1, lbd_stat=False)
+                                      norm=-1, status=True, lbd_stat=False)
 
                     temp_dict[e] = ps
 
@@ -462,6 +462,8 @@ class ParamModel(Atom):
             for key in self.EC.element_dict.keys():
                 if key in element_status:
                     self.EC.element_dict[key].status = element_status[key]
+
+        self.result_dict_names = list(self.EC.element_dict.keys())
 
     def get_selected_eline_energy_fwhm(self, eline):
         """

--- a/pyxrf/model/parameters.py
+++ b/pyxrf/model/parameters.py
@@ -49,7 +49,7 @@ class PreFitStatus(Atom):
     maxv : float
         max value of a spectrum
     norm : float
-        norm value respect to the strongest peak
+        norm value in respect to the strongest peak
     lbd_stat : bool
         define plotting status under a threshold value
     """
@@ -208,7 +208,7 @@ class ElementController(object):
         return remove_list
 
 
-class GuessParamModel(Atom):
+class ParamModel(Atom):
     """
     This is auto fit model to guess the initial parameters.
 
@@ -1238,12 +1238,9 @@ def calculate_profile(x, y, param, elemental_lines,
     y : array
         spectrum intensity
     param : dict
-        paramters
+        parameters
     elemental_lines : list
         such as Si_K, Pt_M
-    required_length : optional, int
-        the length of the array might change due to trim process, so
-        predifine the length to a given value.
     default_area : float
         default value for the gaussian area of each element
 
@@ -1319,7 +1316,7 @@ def trim_escape_peak(data, param_dict, y_size):
 def create_full_dict(param, name_list,
                      fixed_list=['adjust_element2', 'adjust_element3']):
     """
-    Create full param dict so each item has same nested dict.
+    Create full param dict so each item has the same nested dict.
     This is for GUI purpose only.
 
     Pamameters
@@ -1339,7 +1336,6 @@ def create_full_dict(param, name_list,
             if k == 'non_fitting_values':
                 continue
             if n not in v:
-
                 # enforce newly created parameter to be fixed
                 # for strategy in fixed_list
                 if n in fixed_list:

--- a/pyxrf/model/parameters.py
+++ b/pyxrf/model/parameters.py
@@ -479,6 +479,10 @@ class ParamModel(Atom):
 
                     temp_dict[e] = ps
 
+        # TODO: the following block can be simplified: it looks like the only case when status
+        #    can change is when new elements (temp_dict) are already present in 'EC.element_dict'.
+        #    So there is no need to copy the whole dictionary. It should be sufficient to keep
+        #    only old 'status' data for the new elements.
         element_dict = copy.deepcopy(self.EC.element_dict)
         self.EC.add_to_dict(temp_dict)
         for key in self.EC.element_dict.keys():

--- a/pyxrf/model/parameters.py
+++ b/pyxrf/model/parameters.py
@@ -210,7 +210,7 @@ class ElementController(object):
 
 class ParamModel(Atom):
     """
-    This is auto fit model to guess the initial parameters.
+    The module used for maintaing the set of fitting parameters.
 
     Attributes
     ----------

--- a/pyxrf/model/parameters.py
+++ b/pyxrf/model/parameters.py
@@ -271,10 +271,10 @@ class ParamModel(Atom):
     n_selected_elines_for_fitting = Int(0)
     n_selected_pure_elines_for_fitting = Int(0)
 
-    def __init__(self, **kwargs):
+    def __init__(self, *, default_parameters):
         try:
             # default parameter is the original parameter, for user to restore
-            self.default_parameters = kwargs['default_parameters']
+            self.default_parameters = default_parameters
             self.param_new = copy.deepcopy(self.default_parameters)
             # TODO: do we set 'element_list' as a list of keys of 'EC.element_dict'
             self.element_list = get_element_list(self.param_new)

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -3,11 +3,10 @@ from __future__ import (absolute_import, division,
 
 import numpy as np
 from collections import OrderedDict
-import copy
 import os
 import re
 
-from atom.api import (Atom, Str, observe, Dict, List, Int, Bool)
+from atom.api import (Atom, Str, observe, Dict, List, Int, Bool, Typed)
 
 from skbeam.fluorescence import XrfElement as Element
 from skbeam.core.fitting.xrf_model import K_LINE, L_LINE, M_LINE
@@ -102,7 +101,9 @@ class SettingModel(Atom):
     suffix_name_roi : str
         The suffix may have values 'sum', 'det1', 'det2' etc.
     """
-    parameters = Dict()
+    # Reference to ParamModel object
+    param_model = Typed(object)
+
     data_sets = Dict()
     img_dict = Dict()
 
@@ -179,9 +180,9 @@ class SettingModel(Atom):
             # Else keep the original title
             self.data_title_adjusted = self.data_title
 
-    def __init__(self, *, default_parameters):
-        self.parameters = default_parameters
+    def __init__(self, *, param_model):
         # Initialize with an empty string (no elements selected)
+        self.param_model = param_model
         self.element_for_roi = ""
         self.enable_roi_computation = False
 
@@ -243,9 +244,6 @@ class SettingModel(Atom):
             with the @observe decorator
         """
         self.img_dict = change['value']
-
-    def update_parameter(self, param):
-        self.parameters = copy.deepcopy(param)
 
     def select_elements_from_list(self, element_list):
         self.element_for_roi = ', '.join(element_list)
@@ -321,8 +319,8 @@ class SettingModel(Atom):
         Calculate the std at given energy.
         """
         temp_val = 2 * np.sqrt(2 * np.log(2))
-        return np.sqrt((self.parameters['fwhm_offset']['value']/temp_val)**2 +
-                       energy*epsilon*self.parameters['fwhm_fanoprime']['value'])
+        return np.sqrt((self.param_model.param_new['fwhm_offset']['value']/temp_val)**2 +
+                       energy*epsilon*self.param_model.param_new['fwhm_fanoprime']['value'])
 
     def get_roi_sum(self):
         """
@@ -340,18 +338,18 @@ class SettingModel(Atom):
         logger.info(f"Computing ROIs for dataset {self.data_title} ...")
 
         snip_param = {
-            "e_offset": self.parameters["e_offset"]["value"],
-            "e_linear": self.parameters["e_linear"]["value"],
-            "e_quadratic": self.parameters["e_quadratic"]["value"],
-            "b_width": self.parameters["non_fitting_values"]["background_width"]
+            "e_offset": self.param_model.param_new["e_offset"]["value"],
+            "e_linear": self.param_model.param_new["e_linear"]["value"],
+            "e_quadratic": self.param_model.param_new["e_quadratic"]["value"],
+            "b_width": self.param_model.param_new["non_fitting_values"]["background_width"]
         }
 
         n_bin_low, n_bin_high = get_energy_bin_range(
             num_energy_bins=datav.shape[2],
-            low_e=self.parameters['non_fitting_values']['energy_bound_low']['value'],
-            high_e=self.parameters['non_fitting_values']['energy_bound_high']['value'],
-            e_offset=self.parameters['e_offset']['value'],
-            e_linear=self.parameters['e_linear']['value'])
+            low_e=self.param_model.param_new['non_fitting_values']['energy_bound_low']['value'],
+            high_e=self.param_model.param_new['non_fitting_values']['energy_bound_high']['value'],
+            e_offset=self.param_model.param_new['e_offset']['value'],
+            e_linear=self.param_model.param_new['e_linear']['value'])
 
         # Prepare the 'roi_dict' parameter for computations
         roi_dict = {_: (self.roi_dict[_].left_val/1000.0, self.roi_dict[_].right_val/1000.0)

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -103,8 +103,9 @@ class SettingModel(Atom):
     """
     # Reference to ParamModel object
     param_model = Typed(object)
+    # Reference to FileIOModel object
+    io_model = Typed(object)
 
-    data_sets = Dict()
     img_dict = Dict()
 
     element_for_roi = Str()
@@ -180,9 +181,10 @@ class SettingModel(Atom):
             # Else keep the original title
             self.data_title_adjusted = self.data_title
 
-    def __init__(self, *, param_model):
+    def __init__(self, *, param_model, io_model):
         # Initialize with an empty string (no elements selected)
         self.param_model = param_model
+        self.io_model = io_model
         self.element_for_roi = ""
         self.enable_roi_computation = False
 
@@ -218,19 +220,6 @@ class SettingModel(Atom):
         except Exception as ex:
             logger.warning(f"Incorrect specification of element lines for ROI computation: {ex}")
             self.enable_roi_computation = False
-
-    def data_sets_update(self, change):
-        """
-        Observer function to be connected to the fileio model
-        in the top-level gui.py startup
-
-        Parameters
-        ----------
-        changed : dict
-            This is the dictionary that gets passed to a function
-            with the @observe decorator
-        """
-        self.data_sets = change['value']
 
     def img_dict_update(self, change):
         """
@@ -333,7 +322,7 @@ class SettingModel(Atom):
         """
         roi_result = {}
 
-        datav = self.data_sets[self.data_title].raw_data
+        datav = self.io_model.data_sets[self.data_title].raw_data
 
         logger.info(f"Computing ROIs for dataset {self.data_title} ...")
 

--- a/pyxrf/model/setting.py
+++ b/pyxrf/model/setting.py
@@ -179,8 +179,8 @@ class SettingModel(Atom):
             # Else keep the original title
             self.data_title_adjusted = self.data_title
 
-    def __init__(self, *args, **kwargs):
-        self.parameters = kwargs['default_parameters']
+    def __init__(self, *, default_parameters):
+        self.parameters = default_parameters
         # Initialize with an empty string (no elements selected)
         self.element_for_roi = ""
         self.enable_roi_computation = False


### PR DESCRIPTION
In the original design of PyXRF, each module was keeping its own copy of fitting parameters and references to the raw and processed data. After refactoring, only a single copy of fitting parameters is maintained in `param_model` and each module that is using or modifying the parameters is keeping a reference to `param_model`. All references to raw and processed data were consolidated in `io_model`.