### PR TITLE
Improved support for variable energy axis parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ jobs:
     - os: osx
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.7 NUMPY=1.19
+  allow_failures:
+    - os: osx
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.7 NUMPY=1.19
+
 
 before_install:
   - if [ $FLAKE_8 == 'true' ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,17 @@ jobs:
   fast_finish: true
   include:
     - python: 3.7
-      env: FLAKE8=true NUMPY=1.17  # Separate test case for flake8
+      env: FLAKE8=true NUMPY=1.19  # Separate test case for flake8
     - python: 3.6
-      env: BUILD_DOCS=true SUBMIT_CODECOV=true NUMPY=1.17
+      env: BUILD_DOCS=true SUBMIT_CODECOV=true NUMPY=1.19
     - python: 3.7
-      env: BUILD_DOCS=true SUBMIT_CODECOV=true NUMPY=1.17
+      env: BUILD_DOCS=true SUBMIT_CODECOV=true NUMPY=1.19
     - os: osx
       language: generic
-      env: TRAVIS_PYTHON_VERSION=3.6 NUMPY=1.17
+      env: TRAVIS_PYTHON_VERSION=3.6 NUMPY=1.19
     - os: osx
       language: generic
-      env: TRAVIS_PYTHON_VERSION=3.7 NUMPY=1.17
+      env: TRAVIS_PYTHON_VERSION=3.7 NUMPY=1.19
 
 before_install:
   - if [ $FLAKE_8 == 'true' ]; then
@@ -71,9 +71,10 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda create -y -n testenv python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY
   - conda activate testenv
-  - conda install -y 'scikit-beam>=0.0.23' -c nsls2forge
+  - conda install -y 'scikit-beam>=0.0.24' -c nsls2forge
   #- conda install -y scikit-beam -c nsls2forge
   #- conda update -y scikit-beam -c nsls2forge  # Update, because sometimes a very old version is installed :(
+  - python -m pip install --upgrade pip setuptools
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   - pip install codecov

--- a/=1.20
+++ b/=1.20
@@ -1,0 +1,1 @@
+Requirement already satisfied: numpy in /home/dgavrilov/miniconda3/envs/test_inst/lib/python3.7/site-packages (1.19.2)

--- a/pyxrf/gui_module/main_window.py
+++ b/pyxrf/gui_module/main_window.py
@@ -285,6 +285,8 @@ class MainWindow(QMainWindow):
             self.central_widget.right_panel.tab_preview_plots.preview_plot_spectrum.redraw_preview_plot)
         self.central_widget.left_panel.model_widget.signal_incident_energy_or_range_changed.connect(
             self.wnd_manage_emission_lines.update_widget_data)
+        self.central_widget.left_panel.model_widget.signal_incident_energy_or_range_changed.connect(
+            self.central_widget.right_panel.tab_plot_fitting_model.redraw_plot_fit)
 
         self.central_widget.left_panel.model_widget.signal_model_loaded.connect(
             self.central_widget.right_panel.tab_preview_plots.preview_plot_spectrum.redraw_preview_plot)

--- a/pyxrf/gui_module/tab_wd_plots_fitting_model.py
+++ b/pyxrf/gui_module/tab_wd_plots_fitting_model.py
@@ -222,3 +222,8 @@ class PlotFittingModel(QWidget):
     def slot_update_add_remove_btn_state(self, add_enabled, remove_enabled):
         self.pb_add_line.setEnabled(add_enabled)
         self.pb_remove_line.setEnabled(remove_enabled)
+
+    @Slot()
+    @Slot(bool)
+    def redraw_plot_fit(self):
+        self.gpc.update_plot_fit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ numpy>=1.15
 pandas
 pillow
 progress
-pystackreg
+pystackreg==0.2.2
 pyyaml
 qtpy
 requests


### PR DESCRIPTION
A number of changes for supporting updates of the spectrum plots  when parameters of energy axis are changed.

`pystackreg` was pinned to v2.2, since the newer version v2.5 requires numpy>=1.20. `pystackgreg` can be unpinned once Numpy v1.20 is available from `conda`.

OSX Python 3.7 unit test fails with error while building `numba`. The test is set as `allowed to fail`.