### PR TITLE
FIX: compatibility with Matplotlib 3.4

### DIFF
--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -704,7 +704,8 @@ class DrawImageAdvanced(Atom):
                 grid[i].text(0, 1.01, grid_title, ha='left', va='bottom', transform=grid[i].axes.transAxes)
 
                 grid.cbar_axes[i].colorbar(im)
-                im.colorbar.formatter = im.colorbar.cbar_axis.get_major_formatter()
+                im.colorbar.formatter = im.colorbar.ax.yaxis.get_major_formatter()
+
                 # im.colorbar.ax.get_xaxis().set_ticks([])
                 # im.colorbar.ax.get_xaxis().set_ticks([], minor=True)
                 grid.cbar_axes[i].ticklabel_format(style='sci', scilimits=(-3, 4), axis='both')
@@ -764,10 +765,10 @@ class DrawImageAdvanced(Atom):
                 grid[i].text(0, 1.01, grid_title, ha='left', va='bottom', transform=grid[i].axes.transAxes)
 
                 grid.cbar_axes[i].colorbar(im)
-                im.colorbar.formatter = im.colorbar.cbar_axis.get_major_formatter()
+                im.colorbar.formatter = im.colorbar.ax.yaxis.get_major_formatter()
                 im.colorbar.ax.get_xaxis().set_ticks([])
                 im.colorbar.ax.get_xaxis().set_ticks([], minor=True)
-                im.colorbar.cbar_axis.set_minor_formatter(mticker.LogFormatter())
+                im.colorbar.ax.yaxis.set_minor_formatter(mticker.LogFormatter())
 
             grid[i].get_xaxis().set_major_locator(mticker.MaxNLocator(nbins="auto"))
             grid[i].get_yaxis().set_major_locator(mticker.MaxNLocator(nbins="auto"))

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -1437,7 +1437,8 @@ class LinePlotModel(Atom):
 
         if self._ax_preview:
             self._ax_preview.clear()
-        self._ax_preview = self._fig_preview.add_subplot(111)
+        else:
+            self._ax_preview = self._fig_preview.add_subplot(111)
         self._ax_preview.set_facecolor('lightgrey')
         self._ax_preview.grid(which="both")
 
@@ -1812,7 +1813,8 @@ class LinePlotModel(Atom):
                 grid[i].text(0, 1.01, grid_title, ha='left', va='bottom', transform=grid[i].axes.transAxes)
 
                 grid.cbar_axes[i].colorbar(im)
-                im.colorbar.formatter = im.colorbar.cbar_axis.get_major_formatter()
+
+                im.colorbar.formatter = im.colorbar.ax.yaxis.get_major_formatter()
                 # im.colorbar.ax.get_xaxis().set_ticks([])
                 # im.colorbar.ax.get_xaxis().set_ticks([], minor=True)
                 grid.cbar_axes[i].ticklabel_format(style='sci', scilimits=(-3, 4), axis='both')
@@ -1859,10 +1861,10 @@ class LinePlotModel(Atom):
                 grid[i].text(0, 1.01, grid_title, ha='left', va='bottom', transform=grid[i].axes.transAxes)
 
                 grid.cbar_axes[i].colorbar(im)
-                im.colorbar.formatter = im.colorbar.cbar_axis.get_major_formatter()
+                im.colorbar.formatter = im.colorbar.ax.yaxis.get_major_formatter()
                 im.colorbar.ax.get_xaxis().set_ticks([])
                 im.colorbar.ax.get_xaxis().set_ticks([], minor=True)
-                im.colorbar.cbar_axis.set_minor_formatter(mticker.LogFormatter())
+                im.colorbar.ax.yaxis.set_minor_formatter(mticker.LogFormatter())
 
             grid[i].get_xaxis().set_major_locator(mticker.MaxNLocator(nbins="auto"))
             grid[i].get_yaxis().set_major_locator(mticker.MaxNLocator(nbins="auto"))

--- a/pyxrf/pyxrf_run.py
+++ b/pyxrf/pyxrf_run.py
@@ -20,6 +20,9 @@ logger = logging.getLogger("pyxrf")
 
 def run():
     """Run the application"""
+    # import faulthandler
+    # faulthandler.enable()
+
     parser = argparse.ArgumentParser(prog='pyxrf', description='Command line arguments')
     parser.add_argument("-l", "--loglevel", default="INFO", type=str, dest="loglevel",
                         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ distributed
 jsonschema
 h5py>=2.9.0
 lmfit
-matplotlib
+matplotlib!=3.3.*
 numba
 numpy>=1.15
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ distributed
 jsonschema
 h5py>=2.9.0
 lmfit
-matplotlib<=3.2.2
+matplotlib
 numba
 numpy>=1.15
 pandas


### PR DESCRIPTION
The changes ensure that PyXRF will work once Matplotlib 3.4 is released. The changes include:

- Deprecated and removed `Colorbar.cbar_axis` is replaced by `Colorbar.ax.yaxis`.
- Plotting code is changed to ensure that subplot is created only once.

PyXRF will still segfault if used with Matplotlib 3.3, so Matplotlib 3.3.* is disabled in `requirements.txt`.

Special thanks to @tacaswell for help with solving the issues.
