### PR TITLE
Clearing the cache in case of 'databroker.v0'

### DIFF
--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -2111,9 +2111,12 @@ def clear_handler_cache(hdr):
 
 # TODO: the following function may be deleted after Databroker 0.13 is forgotten
 def free_memory_from_handler():
-    """Quick way to set 3D dataset at handler to None to release memory.
     """
-    if LooseVersion(databroker.__version__) < LooseVersion('1.0.0'):
+    Quick way to set 3D dataset at handler to None to release memory.
+    """
+    # The following check is redundant: Data Broker prior to version 1.0.0 always has '_handler_cache'.
+    #   In later versions of databroker  the attribute may still be present if 'databroker.v0' is used.
+    if (LooseVersion(databroker.__version__) < LooseVersion('1.0.0')) or hasattr(db.fs, "_handler_cache"):
         for h in db.fs._handler_cache.values():
             setattr(h, '_dataset', None)
         print('Memory is released.')

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -2115,7 +2115,7 @@ def free_memory_from_handler():
     Quick way to set 3D dataset at handler to None to release memory.
     """
     # The following check is redundant: Data Broker prior to version 1.0.0 always has '_handler_cache'.
-    #   In later versions of databroker  the attribute may still be present if 'databroker.v0' is used.
+    #   In later versions of databroker the attribute may still be present if 'databroker.v0' is used.
     if (LooseVersion(databroker.__version__) < LooseVersion('1.0.0')) or hasattr(db.fs, "_handler_cache"):
         for h in db.fs._handler_cache.values():
             setattr(h, '_dataset', None)


### PR DESCRIPTION
Explicit clearing of the cache was disabled if Data Broker v1.0.0 or above was installed. It led to incorrect behavior, if 'old' Data Broker  `databroker.v0` was used. Changes in this PR restore the correct functionality by verifying if attribute `handler_cache` exists (`hasattr(db.fs, "_handler_cache")`) and explicitly clearing the cache if it does.

The changes will be checked at the beamline before the PR is merged.