### PR TITLE
CI: Unpinned `pystackreg`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,20 @@ jobs:
       env: BUILD_DOCS=true SUBMIT_CODECOV=true NUMPY=1.20
     - os: osx
       language: generic
-      env: TRAVIS_PYTHON_VERSION=3.6 NUMPY=1.19
+      env: TRAVIS_PYTHON_VERSION=3.6 NUMPY=1.20
     - os: osx
       language: generic
-      env: TRAVIS_PYTHON_VERSION=3.7 NUMPY=1.19
+      env: TRAVIS_PYTHON_VERSION=3.7 NUMPY=1.20
+    - os: osx
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.8 NUMPY=1.20
+    - os: osx
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.9 NUMPY=1.20
   allow_failures:
-    - python: 3.9
-      env: BUILD_DOCS=true SUBMIT_CODECOV=true NUMPY=1.20
+    - os: osx
+      language: generic
+      env: TRAVIS_PYTHON_VERSION=3.9 NUMPY=1.20
 
 before_install:
   - if [ $FLAKE_8 == 'true' ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,10 @@ jobs:
       env: BUILD_DOCS=true SUBMIT_CODECOV=true NUMPY=1.20
     - os: osx
       language: generic
-      env: TRAVIS_PYTHON_VERSION=3.6 NUMPY=1.20
-    - os: osx
-      language: generic
       env: TRAVIS_PYTHON_VERSION=3.7 NUMPY=1.20
     - os: osx
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.8 NUMPY=1.20
-    - os: osx
-      language: generic
-      env: TRAVIS_PYTHON_VERSION=3.9 NUMPY=1.20
-  allow_failures:
     - os: osx
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.9 NUMPY=1.20

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,12 @@ install:
   #- conda install -y scikit-beam -c nsls2forge
   #- conda update -y scikit-beam -c nsls2forge  # Update, because sometimes a very old version is installed :(
   - python -m pip install --upgrade pip setuptools
+  - |
+    set -e
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      # There are issues in building wheels for pystackreg>0.2.2 on OSX, so install pystackreg from CF
+      conda install -y pystackreg -c conda-forge
+    fi
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   - pip install codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ numpy>=1.15
 pandas
 pillow
 progress
-pystackreg==0.2.2
+pystackreg
 pyyaml
 qtpy
 requests


### PR DESCRIPTION
Unpinned `pystackreg`. Removed OSX Python 3.6 tests from CI. Added tests with Python 3.8 and Python 3.9 for OSX.