### PR TITLE
Improvements in functionality of 'save_data_to_hdf5' and 'read_data_from_hdf5'

### DIFF
--- a/pyxrf/__init__.py
+++ b/pyxrf/__init__.py
@@ -7,6 +7,3 @@ del get_versions
 
 logger = logging.getLogger("pyxrf")
 logger.addHandler(NullHandler())
-
-from .model.load_data_from_db import save_data_to_hdf5  # noqa: F401, E402
-from .model.fileio import read_data_from_hdf5  # noqa: F401, E402

--- a/pyxrf/api_dev.py
+++ b/pyxrf/api_dev.py
@@ -15,6 +15,9 @@ from .xanes_maps.xanes_maps_api import build_xanes_map  # noqa: F401
 from .simulation.sim_xrf_scan_data import gen_hdf5_qa_dataset, gen_hdf5_qa_dataset_preset_1  # noqa: F401
 from .core.map_processing import dask_client_create  # noqa: F401
 
+from .model.load_data_from_db import save_data_to_hdf5  # noqa: F401, E402
+from .model.fileio import read_data_from_hdf5  # noqa: F401, E402
+
 # Note:  the statement '# noqa: F401' is telling flake8 to ignore violation F401 at the given line
 #     Violation F401 - the package is imported but unused
 

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -2066,7 +2066,10 @@ def save_data_to_hdf5(
     data : dict
         The dictionary of raw data.
     metadata : dict
-        Metadata to be saved in the HDF5 file.
+        Metadata to be saved in the HDF5 file. The function will add or overwrite the existing
+        metadata fields: ``file_type``, ``file_format``, ``file_format_version``, ``file_created_time``.
+        User may define metadata fields ``file_software`` and ``file_software_version``. If ``file_software``
+        is not defined, then the default values for ``file_software`` and ``file_software_version`` are added.
     fname_add_version : boolean
         True: if file already exists, then file version is added to the file name
         so that it becomes unique in the current directory. The version is
@@ -2134,13 +2137,18 @@ def save_data_to_hdf5(
             "file_type": "XRF-MAP",
             "file_format": "NSLS2-XRF-MAP",
             "file_format_version": "1.0",
+            "file_created_time": ttime.strftime("%Y-%m-%dT%H:%M:%S+00:00", ttime.localtime()),
+        }
+
+        metadata_software_version = {
             "file_software": "PyXRF",
             "file_software_version": pyxrf_version,
-            "file_created_time": ttime.strftime("%Y-%m-%dT%H:%M:%S+00:00", ttime.localtime()),
         }
 
         metadata_prepared = metadata or {}
         metadata_prepared.update(metadata_additional)
+        if "file_software" not in metadata_prepared:
+            metadata_prepared.update(metadata_software_version)
 
         if metadata:
             # We assume, that metadata does not contain repeated keys. Otherwise the

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -2105,8 +2105,7 @@ def save_data_to_hdf5(
         logger.debug(
             f"Attemptying to save raw fluorescence data for the channel '{channel}' "
             f"as '{data_type}' numbers.\n    Memory may be used inefficiently. "
-            f"Please, inform the PyXRF developers.\n    The data is converted from '{data_type}' "
-            f"to 'np.float32' before saving to file."
+            f"The data is converted from '{data_type}' to 'np.float32' before saving to file."
         )
 
     if "det_sum" in data and isinstance(data["det_sum"], np.ndarray):

--- a/pyxrf/model/tests/test_hdf5_file_operations.py
+++ b/pyxrf/model/tests/test_hdf5_file_operations.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import numpy.testing as npt
 import pytest
-from pyxrf import save_data_to_hdf5, read_data_from_hdf5
+from pyxrf.api_dev import save_data_to_hdf5, read_data_from_hdf5
 
 
 def _prepare_raw_dataset(N=5, M=10, K=4096):


### PR DESCRIPTION
Some minor improvements in `save_data_to_hdf5` and `read_data_from_hdf5` functions for more consistency and better treatment of metadata. The functions now must be imported from `pyxrf.api` or `pyxrf.api_dev`, which is consistent with the other function.