### PR TITLE
Fix issue with loading corrupt files at TES

### DIFF
--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1424,7 +1424,6 @@ def map_data2D_tes(
             n_max_points = -1  # Maximum number of points in the row
             for row_data in s_data:
                 n_max_points = max(n_max_points, _get_row_len(row_data))
-            print(f"scaler: name={name} n_max_points={n_max_points}")
 
             # Fix for the issue: 'empty' rows in scaler data. Fill 'empty' row
             #   with the nearest (preceding) row.
@@ -1482,7 +1481,6 @@ def map_data2D_tes(
         n_pt_max = max(data_det1.shape[0], n_pt_max)
         data_det1_adjusted = np.zeros([n_pt_max, data_det1.shape[1]])
         data_det1_adjusted[:data_det1.shape[0], :] = data_det1
-        print(f"n={n} data_det1.shape={data_det1.shape}")
 
         detector_data[n, :, :] = data_det1_adjusted
         n_events_found = n + 1

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1384,12 +1384,12 @@ def map_data2D_tes(
         """
         Determine if the row is missing. Different versions of Databroker will return differnent value types.
         """
-        if s_data[_n] is None:
+        if row_data is None:
             return True
-        elif isinstance(s_data[_n], np.ndarray) and (s_data[_n].size == 1) and (s_data[_n] == np.array(None)):
+        elif isinstance(row_data, np.ndarray) and (row_data.size == 1) and (row_data == np.array(None)):
             # This is returned by databroker.v0
             return True
-        elif not len(s_data[_n]):
+        elif not len(row_data):
             return True
         else:
             return False

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1468,14 +1468,23 @@ def map_data2D_tes(
     n_events = data_shape[0]
     n_events_found = 0
     e = hdr.events(fill=True, stream_name="primary")
+
+    n_pt_max = -1
     for n, v in enumerate(e):
         if n >= n_events:
             print("The number of lines is less than expected")
             break
         data = v.data[detector_field]
         data_det1 = np.array(data[:, 0, :], dtype=np.float32)
+
+        # The following is the fix for the case when data has corrupt row (smaller number of data points).
+        # It will not work if the first row is corrupt.
+        n_pt_max = max(data_det1.shape[0], n_pt_max)
+        data_det1_adjusted = np.zeros([n_pt_max, data_det1.shape[1]])
+        data_det1_adjusted[:data_det1.shape[0], :] = data_det1
         print(f"n={n} data_det1.shape={data_det1.shape}")
-        detector_data[n, :, :] = data_det1
+
+        detector_data[n, :, :] = data_det1_adjusted
         n_events_found = n + 1
     if n_events_found < n_events:
         print("The number of lines is less than expected. The experiment may be incomplete")

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1402,7 +1402,6 @@ def map_data2D_tes(
 
     # Typically the scalers are saved
     if save_scaler is True:
-
         # Read the scalers
         scaler_names = config_data["scaler_list"]
 
@@ -1425,6 +1424,7 @@ def map_data2D_tes(
             n_max_points = -1  # Maximum number of points in the row
             for row_data in s_data:
                 n_max_points = max(n_max_points, _get_row_len(row_data))
+            print(f"scaler: name={name} n_max_points={n_max_points}")
 
             # Fix for the issue: 'empty' rows in scaler data. Fill 'empty' row
             #   with the nearest (preceding) row.
@@ -1440,7 +1440,7 @@ def map_data2D_tes(
                 if _is_row_missing(s_data[_n]) or (len(s_data[_n]) < n_max_points):
                     s_data[_n] = np.copy(s_data[n_full])
                     logger.error(
-                        f"Scaler '{name}': row #{_n} is currupted or contains no data. "
+                        f"Scaler '{name}': row #{_n} is corrupt or contains no data. "
                         f"Replaced by data from row #{n_full}"
                     )
                 else:
@@ -1474,6 +1474,7 @@ def map_data2D_tes(
             break
         data = v.data[detector_field]
         data_det1 = np.array(data[:, 0, :], dtype=np.float32)
+        print(f"n={n} data_det1.shape={data_det1.shape}")
         detector_data[n, :, :] = data_det1
         n_events_found = n + 1
     if n_events_found < n_events:

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1480,7 +1480,7 @@ def map_data2D_tes(
         # It will not work if the first row is corrupt.
         n_pt_max = max(data_det1.shape[0], n_pt_max)
         data_det1_adjusted = np.zeros([n_pt_max, data_det1.shape[1]])
-        data_det1_adjusted[:data_det1.shape[0], :] = data_det1
+        data_det1_adjusted[: data_det1.shape[0], :] = data_det1
 
         detector_data[n, :, :] = data_det1_adjusted
         n_events_found = n + 1


### PR DESCRIPTION
Fix the issue with loading corrupt data at TES beamline. The dataset contained one row with smaller number of data points (420 instead of 900). The corrupt row occurred due to acquisition being suspended after beam dump and then resumed.