### PR TITLE
Fixed 'external_repository' name for Doc publishing

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -42,7 +42,7 @@ jobs:
         deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
         publish_branch: master
         publish_dir: ./docs/build/html
-        external_repository: PyXRF/nsls-ii.github.io
+        external_repository: nsls-ii/nsls-ii.github.io
         destination_dir: PyXRF
         keep_files: true  # Keep old files.
         force_orphan: false  # Keep git history.

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -43,6 +43,6 @@ jobs:
         publish_branch: master
         publish_dir: ./docs/build/html
         external_repository: nsls-ii/nsls-ii.github.io
-        destination_dir: PyXRF
+        destination_dir: ${{ env.REPOSITORY_NAME }}  # just the repo name
         keep_files: true  # Keep old files.
         force_orphan: false  # Keep git history.

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -15,6 +15,11 @@ jobs:
       fail-fast: false
 
     steps:
+    - name: Set env.REPOSITORY_NAME  # just the repo, as opposed to org/repo
+      shell: bash -l {0}
+      run: |
+        export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}
+        echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2


### PR DESCRIPTION
Changed external repository name from `PyXRF/nsls-ii.github.io` to `nsls-ii/nsls-ii.github.io`. This may fix the issue of publishing documentation.