### PR TITLE
Fix publishing docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = PyXRF
 SOURCEDIR     = .
-BUILDDIR      = _build
+BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION
This PR makes the target build dir for the docs consistent with the rest of the projects (e.g. [bluesky](https://github.com/bluesky/bluesky/blob/452cf4cab041688186ba00048f88abc491068468/docs/Makefile#L8)) and [https://github.com/NSLS-II/scientific-python-cookiecutter](https://github.com/NSLS-II/scientific-python-cookiecutter/blob/b1da4b795f21292c2588379ea93041eee9ef3eee/%7B%7B%20cookiecutter.repo_name%20%7D%7D/docs/Makefile#L9).