### PR TITLE
Change directory for doc building to a standard 'build'

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = PyXRF
 SOURCEDIR     = .
-BUILDDIR      = _build
+BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -8,7 +8,7 @@ if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
 set SOURCEDIR=.
-set BUILDDIR=_build
+set BUILDDIR=build
 set SPHINXPROJ=PyXRF
 
 if "%1" == "" goto help


### PR DESCRIPTION
Change the directory for building the docs to standard `/docs/build/html`. This is expected to fix doc publishing.