### PR TITLE
Changed 'external_repository' name in deployment script

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -47,7 +47,7 @@ jobs:
         deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
         publish_branch: master
         publish_dir: ./docs/build/html
-        external_repository: nsls-ii/nsls-ii.github.io
+        external_repository: NSLS-II/NSLS-II.github.io
         destination_dir: ${{ env.REPOSITORY_NAME }}  # just the repo name
         keep_files: true  # Keep old files.
         force_orphan: false  # Keep git history.


### PR DESCRIPTION
Changed 'external_repository' name in deployment script from `nsls-ii/nsls-ii.github.io` to `NSLS-II/NSLS-II.github.io`.