### PR TITLE
Fix for the issue of compatibility with Dask `distributed` >= 2019.7.0

### DIFF
--- a/pyxrf/core/map_processing.py
+++ b/pyxrf/core/map_processing.py
@@ -824,6 +824,13 @@ def fit_xrf_map(
 
     result = result_fut.compute(scheduler=client)
 
+    # if file_obj:  ##
+    #     print(f"============ Closing file ======================")  ##
+    #     file_obj.close()  ##
+
+    client.restart()  ##
+    # client.cancel(data) ##
+
     if client_is_local:
         client.close()
 

--- a/pyxrf/core/map_processing.py
+++ b/pyxrf/core/map_processing.py
@@ -520,7 +520,8 @@ def compute_total_spectrum(
 
     result = result_fut.compute(scheduler=client)
 
-    file_obj.close()
+    if file_obj:
+        file_obj.close()
 
     # The following code is needed to cause Dask 'distributed>=2021.7.0' to close the h5file.
     del result_fut
@@ -615,7 +616,8 @@ def compute_total_spectrum_and_count(
 
     result = result_fut.compute(scheduler=client)
 
-    file_obj.close()
+    if file_obj:
+        file_obj.close()
 
     # The following code is needed to cause Dask 'distributed>=2021.7.0' to close the h5file.
     del result_fut
@@ -847,7 +849,8 @@ def fit_xrf_map(
 
     result = result_fut.compute(scheduler=client)
 
-    file_obj.close()
+    if file_obj:
+        file_obj.close()
 
     # The following code is needed to cause Dask 'distributed>=2021.7.0' to close the h5file.
     del result_fut
@@ -1067,7 +1070,8 @@ def compute_selected_rois(
 
     roi_dict_computed = {roi_band_keys[_]: result[:, :, _] for _ in range(len(roi_band_keys))}
 
-    file_obj.close()
+    if file_obj:
+        file_obj.close()
 
     # The following code is needed to cause Dask 'distributed>=2021.7.0' to close the h5file.
     del result_fut

--- a/pyxrf/model/command_tools.py
+++ b/pyxrf/model/command_tools.py
@@ -731,6 +731,7 @@ def pyxrf_batch(
                     dask_client=dask_client,
                 )
             except Exception as ex:
+                logger.exception(ex)  ##
                 if allow_raising_exceptions:
                     _dask_client_close(client_is_local)
                     raise Exception from ex

--- a/pyxrf/model/command_tools.py
+++ b/pyxrf/model/command_tools.py
@@ -731,7 +731,6 @@ def pyxrf_batch(
                     dask_client=dask_client,
                 )
             except Exception as ex:
-                logger.exception(ex)  ##
                 if allow_raising_exceptions:
                     _dask_client_close(client_is_local)
                     raise Exception from ex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 atom
-dask<=2021.6.2
-distributed<=2021.6.2
+dask
+distributed
 jsonschema
 h5py>=2.9.0
 lmfit


### PR DESCRIPTION
This PR contain changes that are necessary for PyXRF to work with `distributed` >= 2019.7.0. No officially supported method to clear Dask cache was found, but Dask tends to release resources and close open files if it is fed with additional small `dummy` task. HDF5 file needs to be opened with `mode='r'` to work with Dask arrays and it needs to be closed before it could be opened with `mode='a'` for writing the result.