### PR TITLE
Add new metadata to HDF5 file (SRX)

### DIFF
--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1583,18 +1583,18 @@ def map_data2D_srx_new(
                 d = dset_list[n]
                 n_pts = d.shape[0]
                 if n_pts != n_row_pts:
-                    print(f"WARNING: Row #{n} has {n_pts} data points. {n_row_pts} points are expected.")
+                    print(f"WARNING: Row #{n + 1} has {n_pts} data points. {n_row_pts} points are expected.")
                     if n_last_good_row == -1:
                         missed_rows.append(n)
                     else:
                         dset_list[n] = np.array(dset_list[n_last_good_row])
-                        print(f"Data in row #{n} is replaced by data from row #{n_last_good_row}")
+                        print(f"Data in row #{n + 1} is replaced by data from row #{n_last_good_row}")
                 else:
                     n_last_good_row = n
                     if missed_rows:
                         for nr in missed_rows:
                             dset_list[nr] = np.array(dset_list[n_last_good_row])
-                            print(f"Data in row #{nr} is replaced by data from row #{n_last_good_row}")
+                            print(f"Data in row #{nr + 1} is replaced by data from row #{n_last_good_row}")
                         missed_rows = []
 
         repair_set(d_xs_sum, n_scan_fast)

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1571,6 +1571,51 @@ def map_data2D_srx_new(
         except Exception as ex:
             logger.error(f"Error occurred while reading data: {ex}. Trying to retrieve available data ...")
 
+        def check_scan_row_length(n_row_pts, n_row_pts_requested, det_name):
+            """
+            Print error message if the number of points per row is different from expected.
+            """
+            if n_row_pts != n_row_pts_requested:
+                print(
+                    f"Unexpected number of scanned points for the detector '{det_name}': {n_row_pts}. "
+                    f"Expected {n_row_pts_requested} points per row."
+                )
+
+        if "xs" in dets:
+            check_scan_row_length(N_xs, n_scan_fast, "xs")
+        if "xs2" in dets:
+            check_scan_row_length(N_xs2, n_scan_fast, "xs2")
+
+        def repair_set(dset_list, n_row_pts):
+            """
+            Replaces corrupt rows (incorrect number of points) with closest 'good' row. This allows to load
+            and use data from corrupt scans. The function will have no effect on 'good' scans.
+            """
+            missed_rows = []
+            n_last_good_row = -1
+            for n in range(len(dset_list)):
+                d = dset_list[n]
+                n_pts = d.shape[-1]
+                if n_pts != n_row_pts:
+                    print(f"Row #{n} has unexpected number of points ({n_pts}): {n_row_pts} points are expected.")
+                    if n_last_good_row == -1:
+                        missed_rows.append(n)
+                    else:
+                        dset_list[n] = np.array(dset_list[n_last_good_row])
+                        print(f"Data for corrupt row #{n} is replaced by data from row #{n_last_good_row}")
+                else:
+                    n_last_good_row = n
+                    if missed_rows:
+                        for nr in missed_rows:
+                            dset_list[nr] = np.array(dset_list[n_last_good_row])
+                            print(f"Data for corrupt row #{nr} is replaced by data from row #{n_last_good_row}")
+                        missed_rows = []
+
+        repair_set(d_xs_sum, N_xs)
+        repair_set(d_xs, N_xs)
+        repair_set(d_xs2_sum, N_xs2)
+        repair_set(d_xs2, N_xs2)
+
         if n_recorded_events != n_scan_slow:
             logger.error(
                 "The number of recorded events (%d) is not equal to the expected number of events (%d): "

--- a/pyxrf/model/scan_metadata.py
+++ b/pyxrf/model/scan_metadata.py
@@ -93,6 +93,13 @@ class ScanMetadataBase:
         printed_keys = set()
         flag_empty_line = False  # Indicates if empty line was just printed
 
+        def _cap(s):
+            """
+            Capitalize the first character of the string. Leave the rest of the characters intact.
+            (``capitalize()`` turns all characters except the first one to lower case)
+            """
+            return s[0].upper() + s[1:] if s else s
+
         for ppattern in self._gen_default_print_order():
             # We don't want to print multiple empty lines in a row
             if ppattern == "" and not flag_empty_line:
@@ -109,8 +116,7 @@ class ScanMetadataBase:
                     s_key = key
                     if key in self.descriptions and self.descriptions[key]:
                         s_key = self.descriptions[key]
-                        # Capitalize the first letter
-                        s_key = s_key.capitalize()
+                        s_key = _cap(s_key)
 
                     if isinstance(v, str):
                         # Wrap the string if it is too long ('fill' function does not change
@@ -212,7 +218,7 @@ class ScanMetadataXRF(ScanMetadataBase):
             "scan_instrument_name": "beamline name",
             "scan_exit_status": "exit status",
             "instrument_mono_incident_energy": "incident energy",
-            "instrument_beam_current": "beam current",
+            "instrument_beam_current": "ring current, mA",
             "instrument_detectors": "detectors",
             "sample_name": "sample name",
             "experiment_plan_name": "plan name",
@@ -243,9 +249,9 @@ class ScanMetadataXRF(ScanMetadataBase):
             "param_fast_axis_units": "fast axis (units)",
             "param_slow_axis": "slow axis",
             "param_slow_axis_units": "slow axis (units)",
-            "param_interferometer_posX": "Interferometer position X (pm)",
-            "param_interferometer_posY": "Interferometer position Y (pm)",
-            "param_interferometer_posZ": "Interferometer position Z (pm)",
+            "param_interferometer_posX": "initial position X (interferometer), pm",
+            "param_interferometer_posY": "initial position Y (interferometer), pm",
+            "param_interferometer_posZ": "initial position Z (interferometer), pm",
         }
 
         return descriptions

--- a/pyxrf/model/scan_metadata.py
+++ b/pyxrf/model/scan_metadata.py
@@ -175,6 +175,9 @@ class ScanMetadataXRF(ScanMetadataBase):
             "param_fast_axis_units",
             "param_slow_axis",
             "param_slow_axis_units",
+            "param_interferometer_posX",
+            "param_interferometer_posY",
+            "param_interferometer_posZ",
             "param.*",
             "",
             "proposal_num",
@@ -240,6 +243,9 @@ class ScanMetadataXRF(ScanMetadataBase):
             "param_fast_axis_units": "fast axis (units)",
             "param_slow_axis": "slow axis",
             "param_slow_axis_units": "slow axis (units)",
+            "param_interferometer_posX": "Interferometer position X (pm)",
+            "param_interferometer_posY": "Interferometer position Y (pm)",
+            "param_interferometer_posZ": "Interferometer position Z (pm)",
         }
 
         return descriptions

--- a/pyxrf/model/scan_metadata.py
+++ b/pyxrf/model/scan_metadata.py
@@ -93,7 +93,7 @@ class ScanMetadataBase:
         printed_keys = set()
         flag_empty_line = False  # Indicates if empty line was just printed
 
-        def _cap(s):
+        def cap(s):
             """
             Capitalize the first character of the string. Leave the rest of the characters intact.
             (``capitalize()`` turns all characters except the first one to lower case)
@@ -116,7 +116,7 @@ class ScanMetadataBase:
                     s_key = key
                     if key in self.descriptions and self.descriptions[key]:
                         s_key = self.descriptions[key]
-                        s_key = _cap(s_key)
+                        s_key = cap(s_key)
 
                     if isinstance(v, str):
                         # Wrap the string if it is too long ('fill' function does not change


### PR DESCRIPTION
Changes:

- Add new metadata entries to HDF5 files for SRX fly scans: `param_interferometer_posX`, `param_interferometer_posY`, `param_interferometer_posZ` and `instrument_beam_current`.

- Implement capability to load corrupt data with some data rows having the number of points less than expected (e.g. scan #102003).