### PR TITLE
Do not hide line plots (total spectrum and fitting) during computation

### DIFF
--- a/pyxrf/gui_module/tab_wd_plots_fitting_model.py
+++ b/pyxrf/gui_module/tab_wd_plots_fitting_model.py
@@ -16,8 +16,7 @@ from matplotlib.backends.backend_qt5agg import (
     NavigationToolbar2QT as NavigationToolbar,
 )
 
-from .useful_widgets import ElementSelection, set_tooltip, global_gui_variables
-
+from .useful_widgets import ElementSelection, set_tooltip  # , global_gui_variables
 from .dlg_plot_escape_peak import DialogPlotEscapePeak
 
 
@@ -153,8 +152,8 @@ class PlotFittingModel(QWidget):
         self.mpl_toolbar.setVisible(self.gui_vars["show_matplotlib_toolbar"])
 
         # Hide Matplotlib canvas during computations
-        state_compute = global_gui_variables["gui_state"]["running_computations"]
-        self.mpl_canvas.setVisible(not state_compute)
+        # state_compute = global_gui_variables["gui_state"]["running_computations"]
+        # self.mpl_canvas.setVisible(not state_compute)
 
     @Slot()
     def update_controls(self):

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -1621,6 +1621,13 @@ class GlobalProcessingClasses:
         self.param_model.EC.update_peak_ratio()
         self.param_model.data_for_plot()
 
+        # update parameter for fit
+        self.param_model.create_full_param()  # Not sure this is needed
+        self.fit_model.apply_default_param()
+
+        # Update displayed intensity of the selected peak
+        self.plot_model.compute_manual_peak_intensity()
+
         if update_plots:
             # update experimental plots in case the coefficients change
             self.plot_model.plot_experiment()
@@ -1628,23 +1635,7 @@ class GlobalProcessingClasses:
             self.plot_model.plot_fit(
                 self.param_model.prefit_x, self.param_model.total_y, self.param_model.auto_fit_all
             )
-
-            # For plotting purposes, otherwise plot will not update
-            if self.plot_model.plot_exp_opt:
-                self.plot_model.plot_exp_opt = False
-                self.plot_model.plot_exp_opt = True
-            else:
-                self.plot_model.plot_exp_opt = True
-                self.plot_model.plot_exp_opt = False
-            self.plot_model.show_fit_opt = False
-            self.plot_model.show_fit_opt = True
-
-        # update parameter for fit
-        self.param_model.create_full_param()  # Not sure this is needed
-        self.fit_model.apply_default_param()
-
-        # Update displayed intensity of the selected peak
-        self.plot_model.compute_manual_peak_intensity()
+            self.plot_model.update_fit_plots()
 
     def total_spectrum_fitting(self):
 

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -1613,7 +1613,7 @@ class GlobalProcessingClasses:
         self.apply_to_fit()
         self.fitting_parameters_changed()
 
-    def apply_to_fit(self):
+    def apply_to_fit(self, *, update_plots=True):
         """
         Update plot, and apply updated parameters to fitting process.
         Note: this is an original function from 'fit.enaml' file.
@@ -1621,22 +1621,23 @@ class GlobalProcessingClasses:
         self.param_model.EC.update_peak_ratio()
         self.param_model.data_for_plot()
 
-        # update experimental plots in case the coefficients change
-        self.plot_model.plot_experiment()
+        if update_plots:
+            # update experimental plots in case the coefficients change
+            self.plot_model.plot_experiment()
 
-        self.plot_model.plot_fit(
-            self.param_model.prefit_x, self.param_model.total_y, self.param_model.auto_fit_all
-        )
+            self.plot_model.plot_fit(
+                self.param_model.prefit_x, self.param_model.total_y, self.param_model.auto_fit_all
+            )
 
-        # For plotting purposes, otherwise plot will not update
-        if self.plot_model.plot_exp_opt:
-            self.plot_model.plot_exp_opt = False
-            self.plot_model.plot_exp_opt = True
-        else:
-            self.plot_model.plot_exp_opt = True
-            self.plot_model.plot_exp_opt = False
-        self.plot_model.show_fit_opt = False
-        self.plot_model.show_fit_opt = True
+            # For plotting purposes, otherwise plot will not update
+            if self.plot_model.plot_exp_opt:
+                self.plot_model.plot_exp_opt = False
+                self.plot_model.plot_exp_opt = True
+            else:
+                self.plot_model.plot_exp_opt = True
+                self.plot_model.plot_exp_opt = False
+            self.plot_model.show_fit_opt = False
+            self.plot_model.show_fit_opt = True
 
         # update parameter for fit
         self.param_model.create_full_param()  # Not sure this is needed
@@ -1648,7 +1649,7 @@ class GlobalProcessingClasses:
     def total_spectrum_fitting(self):
 
         # Update parameter for fit. This may be unnecessary
-        self.apply_to_fit()
+        self.apply_to_fit(update_plots=False)
 
         self.fit_model.fit_multiple()
 

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -610,19 +610,15 @@ class LinePlotModel(Atom):
     @observe("show_fit_opt")
     def _update_fit(self, change):
         if change["type"] != "create":
-            if change["value"]:
-                for v in self.plot_fit_obj:
-                    v.set_visible(True)
-                    lab = v.get_label()
-                    if lab != "_nolegend_":
-                        v.set_label(lab.strip("_"))
-            else:
-                for v in self.plot_fit_obj:
-                    v.set_visible(False)
-                    lab = v.get_label()
-                    if lab != "_nolegend_":
-                        v.set_label("_" + lab)
-            self._update_canvas()
+            self.update_fit_plots(visible=bool(change["value"]))
+
+    def update_fit_plots(self, visible=True):
+        for v in self.plot_fit_obj:
+            v.set_visible(visible)
+            lab = v.get_label()
+            if lab != "_nolegend_":
+                v.set_label(lab.strip("_"))
+        self._update_canvas()
 
     def plot_experiment(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The changes prevent line plots (total spectrum and fitting) from being hidden during computation. The old spectrum remains displayed until the new spectrum is ready, so that the change of the plot is instant and it is easier for the operator to observe changes in fitting.

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

- Line plots are no longer hidden during computations.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
