### PR TITLE
Requested GUI features

### DIFF
--- a/pyxrf/gui_module/wnd_image_wizard.py
+++ b/pyxrf/gui_module/wnd_image_wizard.py
@@ -1,3 +1,4 @@
+import re
 from copy import deepcopy
 from qtpy.QtWidgets import (
     QVBoxLayout,
@@ -48,6 +49,9 @@ class WndImageWizard(SecondaryWindow):
         self.cb_select_all = QCheckBox("All")
         self.cb_select_all.stateChanged.connect(self.cb_select_all_state_changed)
 
+        self.pb_add_elements = QPushButton("Elements")
+        self.pb_add_elements.clicked.connect(self.pb_add_elements_clicked)
+
         self._auto_update = True
         self.cb_auto_update = QCheckBox("Auto")
         self.cb_auto_update.setCheckState(Qt.Checked if self._auto_update else Qt.Unchecked)
@@ -63,6 +67,7 @@ class WndImageWizard(SecondaryWindow):
 
         hbox = QHBoxLayout()
         hbox.addWidget(self.cb_select_all)
+        hbox.addWidget(self.pb_add_elements)
         hbox.addStretch(1)
         hbox.addWidget(self.cb_auto_update)
         hbox.addWidget(self.pb_update_plots)
@@ -200,6 +205,7 @@ class WndImageWizard(SecondaryWindow):
 
     def _set_tooltips(self):
         set_tooltip(self.cb_select_all, "<b>Select/Deselect All</b> emission lines in the list")
+        set_tooltip(self.pb_add_elements, "Add <b>all elements</b> to the selection.")
         set_tooltip(
             self.cb_auto_update,
             "Automatically <b>update the plots</b> when changes are made. "
@@ -230,6 +236,10 @@ class WndImageWizard(SecondaryWindow):
 
     def cb_select_all_state_changed(self, state):
         self._select_all_items(state)
+
+    def pb_add_elements_clicked(self):
+        """Add all elements to selection"""
+        self._add_all_elements_to_selection()
 
     def cb_auto_update_state_changed(self, state):
         self._auto_update = state
@@ -295,6 +305,16 @@ class WndImageWizard(SecondaryWindow):
         for n_row in range(self.table.rowCount()):
             item = self.table.item(n_row, 0)
             item.setCheckState(check_state)
+        self._enable_plot_updates = True
+        self._update_map_selections_auto()
+
+    def _add_all_elements_to_selection(self):
+        """Add all elements to the selection"""
+        self._enable_plot_updates = False
+        for n_row in range(self.table.rowCount()):
+            item = self.table.item(n_row, 0)
+            if re.search("[A-Z][A-Za-z]*_[KLM]", item.text()):
+                item.setCheckState(Qt.Checked)
         self._enable_plot_updates = True
         self._update_map_selections_auto()
 

--- a/pyxrf/gui_module/wnd_image_wizard.py
+++ b/pyxrf/gui_module/wnd_image_wizard.py
@@ -49,7 +49,7 @@ class WndImageWizard(SecondaryWindow):
         self.cb_select_all = QCheckBox("All")
         self.cb_select_all.stateChanged.connect(self.cb_select_all_state_changed)
 
-        self.pb_add_elements = QPushButton("Elements")
+        self.pb_add_elements = QPushButton("Add All Elements")
         self.pb_add_elements.clicked.connect(self.pb_add_elements_clicked)
 
         self._auto_update = True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The PR includes implementation of the following requested GUI features:

- `Add All Elements` button is added to Image Wizard. The button adds all element emission lines to the selection. Issue: https://github.com/NSLS-II/PyXRF/issues/281.
- Absolute energy values are displayed for `Userpeak.._delta_center` parameter in the window 'Fitting Parameters for Individual Emission Lines'. Issue: https://github.com/NSLS-II/PyXRF/issues/282. 
- 'Auto' checkbox is added to the windows 'Fitting Parameters for Individual Emission Lines' and 'Shared Detailed Fitting Parameters'. Issue: https://github.com/NSLS-II/PyXRF/issues/283

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New button `Add All Elements` is added to Image Wizard. The button adds all element emission lines to the selection. 
-  'Auto' checkbox is added to the windows 'Fitting Parameters for Individual Emission Lines' and 'Shared Detailed Fitting Parameters'.

### Changed

- The value of the parameter `Userpeak.._delta_center` is now displayed as absolute energy (true peak position in keV) instead of relative energy (difference between the absolute energy and the 'base' energy 5 keV) in the window 'Fitting Parameters for Individual Emission Lines'.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
