### PR TITLE
Generate position data for course stages (SRX).

### DIFF
--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1595,7 +1595,7 @@ def map_data2D_srx_new(
     scan_doc = start_doc["scan"]
     stop_doc = hdr.stop
 
-    fast_start, fast_stop, fast_pts, slow_start, slow_stop, slow_pts = scan_doc["scan_input"]
+    fast_start, fast_stop, fast_pts, slow_start, slow_stop, slow_pts = scan_doc["scan_input"][:6]
     fast_step = (fast_stop - fast_start) / fast_pts
     slow_step = (slow_stop - slow_start) / slow_pts
 

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1601,6 +1601,8 @@ def map_data2D_srx_new(
     fast_step = (fast_stop - fast_start) / fast_pts
     slow_step = (slow_stop - slow_start) / slow_pts
 
+    snaking_enabled = scan_doc["snake"] == 1
+
     print(f"Scan type: {scan_doc['type']}")
 
     # Check for detectors
@@ -1755,6 +1757,8 @@ def map_data2D_srx_new(
                 if fast_key == "fast_gen":
                     # Generate positions
                     row_pos_fast = np.arange(fast_pts) * fast_step + fast_start
+                    if snaking_enabled and (n_recorded_events % 2):
+                        row_pos_fast = np.flip(row_pos_fast)
                 else:
                     row_pos_fast = data_or_empty_array(v["data"][fast_key])
                 fast_pos.append(row_pos_fast)
@@ -1953,7 +1957,7 @@ def map_data2D_srx_new(
 
     # Consider snake
     # pos_pos, d_xs, d_xs_sum, sclr
-    if scan_doc["snake"] == 1:
+    if snaking_enabled:
         pos_pos[:, 1::2, :] = pos_pos[:, 1::2, ::-1]
         if "xs" in dets or "xs4" in dets:
             if d_xs.size:

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1595,6 +1595,10 @@ def map_data2D_srx_new(
     scan_doc = start_doc["scan"]
     stop_doc = hdr.stop
 
+    fast_start, fast_stop, fast_pts, slow_start, slow_stop, slow_pts = scan_doc["scan_input"]
+    fast_step = (fast_stop - fast_start) / fast_pts
+    slow_step = (slow_stop - slow_start) / slow_pts
+
     print(f"Scan type: {scan_doc['type']}")
 
     # Check for detectors
@@ -1634,32 +1638,30 @@ def map_data2D_srx_new(
     # ===================================================================
     #                     NEW SRX FLY SCAN
     # ===================================================================
+    stages_no_data = ("nano_stage_x", "nano_stage_y", "nano_stage_z", "nano_stage_topx", "nano_stage_topz")
+
     if scan_doc["type"] == "XRF_FLY":
         fast_motor = scan_doc["fast_axis"]["motor_name"]
         if fast_motor == "nano_stage_sx":
             fast_key = "enc1"
-        elif fast_motor == "nano_stage_x":
-            fast_key = "enc1"
         elif fast_motor == "nano_stage_sy":
-            fast_key = "enc2"
-        elif fast_motor == "nano_stage_y":
             fast_key = "enc2"
         elif fast_motor == "nano_stage_sz":
             fast_key = "enc3"
+        elif fast_motor in stages_no_data:
+            fast_key = "fast_gen"
         else:
             raise IOError(f"{fast_motor} not found!")
 
         slow_motor = scan_doc["slow_axis"]["motor_name"]
         if slow_motor == "nano_stage_sx":
             slow_key = "enc1"
-        elif slow_motor == "nano_stage_x":
-            slow_key = "enc1"
         elif slow_motor == "nano_stage_sy":
-            slow_key = "enc2"
-        elif slow_motor == "nano_stage_y":
             slow_key = "enc2"
         elif slow_motor == "nano_stage_sz":
             slow_key = "enc3"
+        elif slow_motor in stages_no_data:
+            slow_key = "slow_gen"
         else:
             slow_key = slow_motor
 
@@ -1748,15 +1750,22 @@ def map_data2D_srx_new(
                         else:
                             sclr_dict[s].append(tmp)
 
-                fast_pos.append(data_or_empty_array(v["data"][fast_key]))
-                if "enc" not in slow_key:
+                if fast_key == "fast_gen":
+                    row_pos_fast = np.arange(fast_pts) * fast_step + fast_start
+                else:
+                    row_pos_fast = data_or_empty_array(v["data"][fast_key])
+                fast_pos.append(row_pos_fast)
+
+                if slow_key == "slow_gen":
+                    row_pos_slow = np.ones(fast_pts) * (n_recorded_events * slow_step + slow_start)
+                elif "enc" not in slow_key:
                     # vp = next(ep)
                     # filler("event", vp)
                     tmp = data_or_empty_array(vp["data"][slow_key])
-                    tmp2 = [tmp] * n_scan_fast
+                    row_pos_slow = np.array([tmp] * n_scan_fast)
                 else:
-                    tmp2 = data_or_empty_array(v["data"][slow_key])
-                slow_pos.append(np.array(tmp2))
+                    row_pos_slow = np.array(data_or_empty_array(v["data"][slow_key]))
+                slow_pos.append(row_pos_slow)
 
                 n_recorded_events = m + 1
 

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1595,6 +1595,8 @@ def map_data2D_srx_new(
     scan_doc = start_doc["scan"]
     stop_doc = hdr.stop
 
+    # The following scan parameters are used to compute positions for some motors.
+    #   (Positions of course stages are not saved during the scan)
     fast_start, fast_stop, fast_pts, slow_start, slow_stop, slow_pts = scan_doc["scan_input"][:6]
     fast_step = (fast_stop - fast_start) / fast_pts
     slow_step = (slow_stop - slow_start) / slow_pts
@@ -1649,7 +1651,7 @@ def map_data2D_srx_new(
         elif fast_motor == "nano_stage_sz":
             fast_key = "enc3"
         elif fast_motor in stages_no_data:
-            fast_key = "fast_gen"
+            fast_key = "fast_gen"  # No positions are saved. Generate positions based on scan parameters.
         else:
             raise IOError(f"{fast_motor} not found!")
 
@@ -1661,7 +1663,7 @@ def map_data2D_srx_new(
         elif slow_motor == "nano_stage_sz":
             slow_key = "enc3"
         elif slow_motor in stages_no_data:
-            slow_key = "slow_gen"
+            slow_key = "slow_gen"  # No positions are saved. Generate positions based on scan parameters.
         else:
             slow_key = slow_motor
 
@@ -1751,12 +1753,14 @@ def map_data2D_srx_new(
                             sclr_dict[s].append(tmp)
 
                 if fast_key == "fast_gen":
+                    # Generate positions
                     row_pos_fast = np.arange(fast_pts) * fast_step + fast_start
                 else:
                     row_pos_fast = data_or_empty_array(v["data"][fast_key])
                 fast_pos.append(row_pos_fast)
 
                 if slow_key == "slow_gen":
+                    # Generate positions
                     row_pos_slow = np.ones(fast_pts) * (n_recorded_events * slow_step + slow_start)
                 elif "enc" not in slow_key:
                     # vp = next(ep)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes to the code, which loads SRX experimental data from Databroker.

Positions of course stages are not captured during flyscans and need to be generated when the data is loaded from Data Broker and saved as HDF5 files. The positions are generated based on input scan parameters from the start document. Positions are generated for the following motors: 

```
"nano_stage_x", "nano_stage_y", "nano_stage_z", "nano_stage_topx", "nano_stage_topz"
```

The motors could be used for fast axis, slow axis and both. The axes are treated independently.

The generated positions are saved to HDF5 file. The HDF5 files can be handled as usual.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

- SRX beamline: The positions for course stages are now generated based on plan input parameters. The following motors are supported: `nano_stage_x`, `nano_stage_y`, `nano_stage_z`, `nano_stage_topx`, `nano_stage_topz`.


### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
