### PR TITLE
Support for Fly1D, dmesh and dscan (HXN)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         host-os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         numpy-version: ["1.21"]
         pyqt-version: ["5.12"]
       fail-fast: false

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -166,6 +166,7 @@ def fetch_data_from_db(
     output_to_file=False,
     save_scaler=True,
     num_end_lines_excluded=None,
+    fail_for_plan_types=None,
 ):
     """
     Read data from databroker.
@@ -211,6 +212,8 @@ def fetch_data_from_db(
         choose to save scaler data or not for srx beamline, test purpose only.
     num_end_lines_excluded : int, optional
         remove the last few bad lines
+    fail_for_plan_types: list(str) or None
+        list of plan type names to ignore, e.g. ['FlyPlan1D']. (Supported only at HXN.)
 
     Returns
     -------
@@ -229,6 +232,7 @@ def fetch_data_from_db(
             successful_scans_only=successful_scans_only,
             file_overwrite_existing=file_overwrite_existing,
             output_to_file=output_to_file,
+            fail_for_plan_types=fail_for_plan_types,
         )
     elif hdr.start.beamline_id == "xf05id" or hdr.start.beamline_id == "SRX":
         data = map_data2D_srx(
@@ -286,6 +290,7 @@ def make_hdf(
     create_each_det=False,
     save_scaler=True,
     num_end_lines_excluded=None,
+    fail_for_plan_types=None,
 ):
     """
     Load data from database and save it in HDF5 files.
@@ -394,6 +399,10 @@ def make_hdf(
         False: do not save scaler data
     num_end_lines_excluded : int, optional
         The number of lines at the end of the scan that will not be saved to the data file.
+    fail_for_plan_types: list(str) or None
+        The list of plan types (e.g. ['FlyPlan1D']) that should cause the loader to raise
+        an exception. The parameter is used to allow scripts to ignore certain plan types
+        when downloading data using ranges of scans IDs. (Supported only at HXN.)
     """
 
     if wd:
@@ -427,6 +436,7 @@ def make_hdf(
             output_to_file=True,
             save_scaler=save_scaler,
             num_end_lines_excluded=num_end_lines_excluded,
+            fail_for_plan_types=fail_for_plan_types,
         )
     else:
         # Both ``start`` and ``end`` are specified. Convert the scans in the range
@@ -647,6 +657,7 @@ def map_data2D_hxn(
     successful_scans_only=False,
     file_overwrite_existing=False,
     output_to_file=True,
+    fail_for_plan_types=None,
 ):
     """
     Save the data from databroker to hdf file.
@@ -706,8 +717,10 @@ def map_data2D_hxn(
     start_doc = hdr["start"]
 
     # Exclude certain types of plans based on data from the start document
-    ##if start_doc["plan_type"] in ("FlyPlan1D",):
-    ##    raise RuntimeError(f"Failed to load the plan: plan {start_doc['plan_type']!r} is not supported")
+    if isinstance(fail_for_plan_types, (list, tuple)) and (start_doc["plan_type"] in fail_for_plan_types):
+        raise RuntimeError(
+            f"Failed to load the plan: plan type {start_doc['plan_type']!r} is in the list of ignored types"
+        )
 
     # The dictionary holding scan metadata
     mdata = _extract_metadata_from_header(hdr)

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -759,7 +759,7 @@ def map_data2D_hxn(
         logger.warning("Angle 'theta' is not found and is not included in the HDF file metadata")
 
     # ------------------------------------------------------------------------------------------------
-    # Dimensions of the scan 
+    # Dimensions of the scan
     if "dimensions" in start_doc:
         datashape = start_doc.dimensions
     elif "shape" in start_doc:
@@ -806,7 +806,7 @@ def map_data2D_hxn(
         fast_axis_index = motors.index(fast_axis, 0)
         slow_axis_index = 0 if (fast_axis_index == 1) else 1
         slow_axis = motors[slow_axis_index]
-    
+
     elif n_dimensions == 1:
         fast_axis, fast_axis_index, slow_axis = pos_list[0], 0, pos_list[1]
 
@@ -857,21 +857,9 @@ def map_data2D_hxn(
 
     data = hdr.table(fields=fields, fill=True)
 
-    # This is for the case of 'dcan' (1D), where the slow axis does not exist
+    # This is for the case of 'dcan' (1D), where the slow axis positions are not saved
     if (slow_axis not in data) and (fast_axis in data):
         data[slow_axis] = np.zeros(shape=data[fast_axis].shape)
-
-    print(f"type(data)={type(data)}") ##
-    print(f"type(data['xspress3_ch1'])={type(data['xspress3_ch1'])}") ##
-    print(f"data['xspress3_ch1']={data['xspress3_ch1']}") ##
-    ## raise Exception("Stop")
-
-    # if n_dimensions == 1:
-    #     for k in det_list:
-    #         if k in data:
-    #             print(f"data[{k}] (before): {data[k].to_numpy()}")  ##
-    #             data[k] = np.expand_dims(data[k].to_numpy(), 1)  # Add another dimension
-    #             print(f"data[{k}] (after): {data[k]}")  ##
 
     data_out = map_data2D(
         data,
@@ -2906,7 +2894,6 @@ def map_data2D(
             # flip position the same as data flip on det counts
             pos_data[:, :, i] = flip_data(pos_data[:, :, i], subscan_dims=subscan_dims)
     new_p = np.zeros([len(pos_names), pos_data.shape[0], pos_data.shape[1]])
-    print(f"new_p.shape={new_p.shape} pos_data.shape={pos_data.shape}")  ##
     for i in range(len(pos_names)):
         new_p[i, :, :] = pos_data[:, :, i]
     data_output["pos_names"] = pos_names

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -764,6 +764,8 @@ def map_data2D_hxn(
         datashape = start_doc.dimensions
     elif "shape" in start_doc:
         datashape = start_doc.shape
+    elif "num_points" in start_doc:
+        datashape = [start_doc.num_points]
     else:
         logger.error("No dimension/shape is defined in hdr.start.")
 
@@ -854,6 +856,11 @@ def map_data2D_hxn(
         fields = None
 
     data = hdr.table(fields=fields, fill=True)
+
+    # This is for the case of 'dcan' (1D), where the slow axis does not exist
+    if (slow_axis not in data) and (fast_axis in data):
+        data[slow_axis] = np.zeros(shape=data[fast_axis].shape)
+
     print(f"type(data)={type(data)}") ##
     print(f"type(data['xspress3_ch1'])={type(data['xspress3_ch1'])}") ##
     print(f"data['xspress3_ch1']={data['xspress3_ch1']}") ##


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Support for `Fly1D`, `dmesh` and `dscan` used at HXN. Now data from those scans can be loaded using `make_hdf`. Additional parameter `fail_for_plan_types` is added to `make_hdf`, which accepts a list of plan types to ignore.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- `make_hdf` now supports `Fly1D`, `dmesh` and `dscan` (HXN).
- New parameter `fail_for_plan_types` is added `make_hdf`. The parameter accepts a list of plan types ignored by `make_hdf` (`make_hdf` is raising an exception when loading a single plan).

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
