### PR TITLE
ENH: reading data with corrupt row(s) (TES)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,5 +7,6 @@ exclude =
     versioneer.py,
     pyxrf/_version.py,
     docs/conf.py
-ignore = E203, W503  # There are some errors produced by 'black', therefore unavoidable
+# There are some errors produced by 'black', therefore unavoidable
+ignore = E203, W503
 max-line-length = 115


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The changes allow loading data with corrupt rows (e.g. missing or corrupt data file). If the corrupt row is in the middle of the scan, it is replaced by the average of the previous and the next row.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Loading data with corrupt rows in the middle of the scan (TES).

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
