### PR TITLE
SRX: extended the set of supported channel names (step scan)

### DIFF
--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1955,12 +1955,14 @@ def map_data2D_srx_new(
         # Get detector data
         keys = hdr.table().keys()
         MAX_DET_ELEMENTS = 8
-        N_xs, det_name_prefix = None, None
+        N_xs, det_name_prefix, ndigits = None, None, 1
         for i in np.arange(1, MAX_DET_ELEMENTS + 1):
             if f"xs_channel{i}" in keys:
-                N_xs, det_name_prefix = i, "xs_channel"
+                N_xs, det_name_prefix, ndigits = i, "xs_channel", 1
+            elif f"xs_channel{i:02d}" in keys:
+                N_xs, det_name_prefix, ndigits = i, "xs_channel", 2
             elif f"xs_channels_channel{i:02d}" in keys:
-                N_xs, det_name_prefix = i, "xs_channels_channel"
+                N_xs, det_name_prefix, ndigits = i, "xs_channels_channel", 2
             else:
                 break
         N_pts = num_events
@@ -1968,10 +1970,9 @@ def map_data2D_srx_new(
         if "xs" in dets or "xs4" in dets:
             d_xs = np.empty((N_xs, N_pts, N_bins))
             for i in np.arange(0, N_xs):
-                if det_name_prefix == "xs_channel":
-                    dname = det_name_prefix + f"{i + 1}"
-                else:
-                    dname = det_name_prefix + f"{i + 1:02d}"
+                chnum = f"{i + 1}" if ndigits == 1 else f"{i + 1:02d}"
+                dname = det_name_prefix + chnum
+
                 d = hdr.data(dname, fill=True)
                 d = np.array(list(d))
                 d_xs[i, :, :] = np.copy(d)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix for compatibility with 2023-1.0 environment. When loading the step scan data, PyXRF recognizes Xspress3 channel names, where channel number is represented using two digits (`xs_channel01`, `xs_channel02` etc. instead of `xs_channel1`, `xs_channel2` etc.). The old channel names are also recognized.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Fixed the code for loading step scan data at SRX. PyXRF can now load the step scan data recorded using 2023-1.0 environment.

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
