### PR TITLE
Extended Quantitative Analysis

### DIFF
--- a/pyxrf/core/quant_analysis.py
+++ b/pyxrf/core/quant_analysis.py
@@ -1641,7 +1641,7 @@ class ParamQuantitativeAnalysis:
         self.experiment_distance_to_sample = distance_to_sample
 
     def apply_quantitative_normalization(
-        self, data_in, *, scaler_dict, scaler_name_default, data_name, name_not_scalable=None
+        self, data_in, *, scaler_dict, scaler_name_default, data_name, ref_name=None, name_not_scalable=None
     ):
         r"""
         Apply quantitative normalization to the experimental XRF map ``data_in``. The quantitative
@@ -1675,16 +1675,11 @@ class ParamQuantitativeAnalysis:
         ----------
 
         data_in: ndarray
-
             XRF map (shape (ny,nx)) needs to be normalized.
-
         scaler_dict: dict(key: str, value: ndarray)
-
             Dictionary of the available scaler data for the experimental scan
             (key: scaler name, value: map of scaler values with shape (ny, nx)).
-
         scaler_name_default: str or None
-
             Name of the default scaler that is selected for the normalization of experimental
             data. If ``scaler_name_fixed`` is None or not found in the dictionary ``scaler_dict``,
             then normalization is not applied. If quanitative calibration data is available
@@ -1692,15 +1687,16 @@ class ParamQuantitativeAnalysis:
             the scaler name that was applied during quantitative calibration is applied.
             If ``scaler_name_fixed`` is ``None``, then normalization is applied only if
             quantitative calibration is available for the emission line ``data_name``.
-
         data_name: str
-
             The name of XRF map ``data_in``. This may be emission line name (such as ``Fe_K``, ``S_K``)
             or the name of the scalar or positional data. If ``data_name`` represents an emission line,
             then quantitative calibration may be applied to the data.
-
+        ref_name: str or None
+            Name of the reference emission line if different from data_name. The name should be an emission
+            line name (such as ``Fe_K``, ``S_K``). If reference is specified (not *None*), then
+            the quantitative calibration data for the reference channel is used for computation.
+            The reference channel MUST have quantitative calibration data.
         name_not_scalable: list or None
-
             List of map names that are not supposed to be normalized (some scalers, time, positions
             should not be normalized by the scaler). Normalization is skipped for this data.
 
@@ -1741,6 +1737,8 @@ class ParamQuantitativeAnalysis:
         #   to run the function without a scaler. The scaler name is None if the standard was
         #   processed without normalization, so the sample data will not be normalized as well.
         #   But the results are expected to be much better if the scaler is used.
+
+        print(f"data_name = {data_name} ============================")  ##
 
         run_quant = False
         if e_info:

--- a/pyxrf/core/quant_analysis.py
+++ b/pyxrf/core/quant_analysis.py
@@ -1792,9 +1792,7 @@ class ParamQuantitativeAnalysis:
         if run_quant and ref_name:
             try:
                 atomic_scaling_factor = compute_atomic_scaling_factor(
-                    ref_eline=ref_name,
-                    quant_eline=data_name,
-                    incident_energy=self.experiment_incident_energy
+                    ref_eline=ref_name, quant_eline=data_name, incident_energy=self.experiment_incident_energy
                 )
             except ValueError as ex:
                 logger.error(ex)

--- a/pyxrf/core/quant_analysis.py
+++ b/pyxrf/core/quant_analysis.py
@@ -1745,9 +1745,6 @@ class ParamQuantitativeAnalysis:
         #   processed without normalization, so the sample data will not be normalized as well.
         #   But the results are expected to be much better if the scaler is used.
 
-        print(f"data_name = {data_name} ============================")  ##
-        print(f"ref_name = {ref_name} ============================")  ##
-
         run_quant = False
         if e_info:
             run_quant = True

--- a/pyxrf/core/quant_analysis.py
+++ b/pyxrf/core/quant_analysis.py
@@ -6,7 +6,12 @@ import math
 import json
 import copy
 import time as ttime
-from .xrf_utils import split_compound_mass, generate_eline_list, compute_atomic_scaling_factor
+from .xrf_utils import (
+    split_compound_mass,
+    generate_eline_list,
+    compute_atomic_scaling_factor,
+    check_if_eline_supported,
+)
 from .utils import normalize_data_by_scaler, convert_time_to_nexus_string
 import logging
 
@@ -1746,7 +1751,7 @@ class ParamQuantitativeAnalysis:
         #   But the results are expected to be much better if the scaler is used.
 
         run_quant = False
-        if e_info:
+        if e_info and check_if_eline_supported(data_name):
             run_quant = True
             e_info_scaler = e_info["scaler_name"]
 

--- a/pyxrf/gui_module/dlg_export_to_tiff_and_txt.py
+++ b/pyxrf/gui_module/dlg_export_to_tiff_and_txt.py
@@ -31,6 +31,8 @@ class DialogExportToTiffAndTxt(QDialog):
         self.__save_txt = False
         self.__interpolate_on = False
         self.__quant_norm_on = False
+        self.__quant_ref_eline_list = []
+        self.__quant_ref_eline = ""
         self.__dset_list = []
         self.__dset_sel = 0
         self.__scaler_list = []
@@ -74,7 +76,7 @@ class DialogExportToTiffAndTxt(QDialog):
             "copied from <b>XRF Maps</b> tab.",
         )
 
-        self.cb_quantitative = QCheckBox("Quantitative normalization")
+        self.cb_quantitative = QCheckBox("Quantitative")
         self.cb_quantitative.setChecked(Qt.Checked if self.__quant_norm_on else Qt.Unchecked)
         self.cb_quantitative.stateChanged.connect(self.cb_quantitative_state_changed)
         set_tooltip(
@@ -83,12 +85,26 @@ class DialogExportToTiffAndTxt(QDialog):
             "The initial choice is copied from <b>XRF Maps</b> tab.",
         )
 
+        self.combo_quant_ref = QComboBox()
+        self.combo_quant_ref.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self.combo_quant_ref.currentIndexChanged.connect(self.combo_quant_ref_current_index_changed)
+        self._fill_quant_ref_combo()
+        set_tooltip(
+            self.combo_quant_ref,
+            "Select reference emission line for <b>Quantitative Normalization</b>.",
+        )
+
         self.group_settings = QGroupBox("Settings (selections from XRF Maps tab)")
         grid = QGridLayout()
         grid.addWidget(self.combo_select_dataset, 0, 0)
         grid.addWidget(self.combo_normalization, 0, 1)
         grid.addWidget(self.cb_interpolate, 1, 0)
-        grid.addWidget(self.cb_quantitative, 1, 1)
+
+        hbox11 = QHBoxLayout()
+        hbox11.addWidget(self.cb_quantitative)
+        hbox11.addWidget(self.combo_quant_ref)
+
+        grid.addLayout(hbox11, 1, 1)
         self.group_settings.setLayout(grid)
 
         self.le_dir_path = LineEditReadOnly()
@@ -206,6 +222,24 @@ class DialogExportToTiffAndTxt(QDialog):
         self.cb_quantitative.setChecked(Qt.Checked if quant_norm_on else Qt.Unchecked)
 
     @property
+    def quant_ref_eline_list(self):
+        return self.__quant_ref_eline_list
+
+    @quant_ref_eline_list.setter
+    def quant_ref_eline_list(self, quant_ref_eline_list):
+        self.__quant_ref_eline_list = quant_ref_eline_list
+        self._fill_quant_ref_combo()
+
+    @property
+    def quant_ref_eline(self):
+        return self.__quant_ref_eline
+
+    @quant_ref_eline.setter
+    def quant_ref_eline(self, quant_ref_eline):
+        self.__quant_ref_eline = quant_ref_eline
+        self.combo_quant_ref.setCurrentText(quant_ref_eline)
+
+    @property
     def dset_list(self):
         return self.__dset_list
 
@@ -282,6 +316,9 @@ class DialogExportToTiffAndTxt(QDialog):
         self.__scaler_sel = index
         self._update_saved_file_groups()
 
+    def combo_quant_ref_current_index_changed(self, index):
+        self.__quant_ref_eline = self.combo_quant_ref.itemText(index)
+
     def get_selected_dset_name(self):
         index = self.__dset_sel - 1
         n = len(self.__dset_list)
@@ -297,6 +334,11 @@ class DialogExportToTiffAndTxt(QDialog):
             return None
         else:
             return self.__scaler_list[index]
+
+    def _fill_quant_ref_combo(self):
+        self.combo_quant_ref.clear()
+        self.combo_quant_ref.addItems([""] + self.__quant_ref_eline_list)
+        self.combo_quant_ref.setCurrentText(self.__quant_ref_eline)
 
     def _fill_dataset_combo(self):
         self.combo_select_dataset.clear()

--- a/pyxrf/gui_module/dlg_export_to_tiff_and_txt.py
+++ b/pyxrf/gui_module/dlg_export_to_tiff_and_txt.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 from qtpy.QtWidgets import (
@@ -227,6 +228,8 @@ class DialogExportToTiffAndTxt(QDialog):
 
     @quant_ref_eline_list.setter
     def quant_ref_eline_list(self, quant_ref_eline_list):
+        quant_ref_eline_list = copy.copy(quant_ref_eline_list)
+        quant_ref_eline_list.sort(key=lambda x: x.lower())
         self.__quant_ref_eline_list = quant_ref_eline_list
         self._fill_quant_ref_combo()
 

--- a/pyxrf/gui_module/main_window.py
+++ b/pyxrf/gui_module/main_window.py
@@ -337,6 +337,9 @@ class MainWindow(QMainWindow):
         self.wnd_load_quantitative_calibration.signal_quantitative_calibration_changed.connect(
             self.central_widget.right_panel.tab_plot_xrf_maps.update_combo_quant_ref
         )
+        self.wnd_load_quantitative_calibration.signal_quantitative_calibration_changed.connect(
+            self.central_widget.right_panel.tab_plot_rgb_maps.update_combo_quant_ref
+        )
 
         self.wnd_load_quantitative_calibration.signal_quantitative_calibration_changed.connect(
             self.central_widget.right_panel.tab_plot_rgb_maps.slot_update_ranges

--- a/pyxrf/gui_module/main_window.py
+++ b/pyxrf/gui_module/main_window.py
@@ -335,6 +335,10 @@ class MainWindow(QMainWindow):
 
         # Quantitative calibration changed
         self.wnd_load_quantitative_calibration.signal_quantitative_calibration_changed.connect(
+            self.central_widget.right_panel.tab_plot_xrf_maps.update_combo_quant_ref
+        )
+
+        self.wnd_load_quantitative_calibration.signal_quantitative_calibration_changed.connect(
             self.central_widget.right_panel.tab_plot_rgb_maps.slot_update_ranges
         )
         self.wnd_load_quantitative_calibration.signal_quantitative_calibration_changed.connect(

--- a/pyxrf/gui_module/tab_wd_fit_maps.py
+++ b/pyxrf/gui_module/tab_wd_fit_maps.py
@@ -304,8 +304,8 @@ class FitMapsWidget(FormBaseWidget):
         dlg.scaler_sel = params["scaler_sel"]
         dlg.interpolate_on = params["interpolate_on"]
         dlg.quant_norm_on = params["quant_norm_on"]
-        dlg.quant_ref_eline = params["quant_ref_eline"]
         dlg.quant_ref_eline_list = params["quant_ref_eline_list"]
+        dlg.quant_ref_eline = params["quant_ref_eline"]
 
         res = dlg.exec()
         if res:

--- a/pyxrf/gui_module/tab_wd_fit_maps.py
+++ b/pyxrf/gui_module/tab_wd_fit_maps.py
@@ -304,6 +304,8 @@ class FitMapsWidget(FormBaseWidget):
         dlg.scaler_sel = params["scaler_sel"]
         dlg.interpolate_on = params["interpolate_on"]
         dlg.quant_norm_on = params["quant_norm_on"]
+        dlg.quant_ref_eline = params["quant_ref_eline"]
+        dlg.quant_ref_eline_list = params["quant_ref_eline_list"]
 
         res = dlg.exec()
         if res:
@@ -313,6 +315,7 @@ class FitMapsWidget(FormBaseWidget):
                 scaler_name = dlg.get_selected_scaler_name()
                 interpolate_on = dlg.interpolate_on
                 quant_norm_on = dlg.quant_norm_on
+                quant_ref_eline = dlg.quant_ref_eline
                 file_formats = []
                 if dlg.save_tiff:
                     file_formats.append("tiff")
@@ -324,6 +327,7 @@ class FitMapsWidget(FormBaseWidget):
                     scaler_name=scaler_name,
                     interpolate_on=interpolate_on,
                     quant_norm_on=quant_norm_on,
+                    quant_ref_eline=quant_ref_eline,
                     file_formats=file_formats,
                 )
                 if file_formats:

--- a/pyxrf/gui_module/tab_wd_plots_xrf_maps.py
+++ b/pyxrf/gui_module/tab_wd_plots_xrf_maps.py
@@ -57,6 +57,10 @@ class PlotXrfMaps(QWidget):
         self.cb_quantitative.setChecked(self.gpc.get_maps_quant_norm_enabled())
         self.cb_quantitative.toggled.connect(self.cb_quantitative_toggled)
 
+        self.combo_quant_ref = QComboBox()
+        self.combo_quant_ref.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self.combo_quant_ref.currentIndexChanged.connect(self.combo_quant_ref_current_index_changed)
+
         self.combo_color_scheme = QComboBox()
         # TODO: make color schemes global
         self._color_schemes = ("viridis", "jet", "bone", "gray", "Oranges", "hot")
@@ -99,6 +103,7 @@ class PlotXrfMaps(QWidget):
         hbox.addWidget(self.combo_normalization)
         hbox.addStretch(3)
         hbox.addWidget(self.cb_quantitative)
+        hbox.addWidget(self.combo_quant_ref)
         hbox.addStretch(1)
         hbox.addWidget(self.combo_linear_log)
         hbox.addWidget(self.combo_pixels_positions)
@@ -142,6 +147,26 @@ class PlotXrfMaps(QWidget):
         state_compute = global_gui_variables["gui_state"]["running_computations"]
         self.mpl_canvas.setVisible(not state_compute)
 
+    def update_combo_quant_ref(self):
+        ref_elines = self.gpc.get_quant_calibration_active_lines()
+        ref_elines.sort(key=lambda x: x.lower())
+        ref_elines = [""] + ref_elines
+
+        # Currently selected emission line
+        current_eline = self.combo_quant_ref.currentText()
+        if current_eline and (current_eline not in ref_elines):
+            current_eline = ""
+
+        elines = [self.combo_quant_ref.itemText(_) for _ in range(self.combo_quant_ref.count())]
+
+        if elines != ref_elines:
+            self.combo_quant_ref.clear()
+            self.combo_quant_ref.addItems(ref_elines)
+            if current_eline:
+                self.combo_quant_ref.setCurrentText(current_eline)
+            else:
+                self.combo_quant_ref.setCurrentIndex(0)
+
     def pb_image_wizard_clicked(self):
         # Position the window in relation ot the main window (only when called once)
         pos = self.ref_main_window.pos()
@@ -163,6 +188,11 @@ class PlotXrfMaps(QWidget):
     def combo_select_dataset_current_index_changed(self, index):
         self.gpc.set_maps_selected_dataset(index + 1)
         self.signal_maps_dataset_selection_changed.emit()
+
+    def combo_quant_ref_current_index_changed(self, index):
+        pass
+        # self.gpc.set_maps_selected_dataset(index + 1)
+        # self.signal_maps_dataset_selection_changed.emit()
 
     @Slot()
     def combo_select_dataset_update_current_index(self):

--- a/pyxrf/gui_module/tab_wd_plots_xrf_maps.py
+++ b/pyxrf/gui_module/tab_wd_plots_xrf_maps.py
@@ -151,6 +151,7 @@ class PlotXrfMaps(QWidget):
         state_compute = global_gui_variables["gui_state"]["running_computations"]
         self.mpl_canvas.setVisible(not state_compute)
 
+    @Slot()
     def update_combo_quant_ref(self):
         ref_elines = self.gpc.get_quant_calibration_active_lines()
         ref_elines.sort(key=lambda x: x.lower())
@@ -194,9 +195,8 @@ class PlotXrfMaps(QWidget):
         self.signal_maps_dataset_selection_changed.emit()
 
     def combo_quant_ref_current_index_changed(self, index):
-        pass
-        # self.gpc.set_maps_selected_dataset(index + 1)
-        # self.signal_maps_dataset_selection_changed.emit()
+        self.gpc.set_maps_quant_ref_eline(self.combo_quant_ref.itemText(index))
+        self.signal_maps_norm_changed.emit()
 
     @Slot()
     def combo_select_dataset_update_current_index(self):

--- a/pyxrf/gui_module/tab_wd_plots_xrf_maps.py
+++ b/pyxrf/gui_module/tab_wd_plots_xrf_maps.py
@@ -128,6 +128,10 @@ class PlotXrfMaps(QWidget):
             self.cb_quantitative,
             "Normalize the displayed XRF maps using loaded <b>Quantitative Calibration</b> data.",
         )
+        set_tooltip(
+            self.combo_quant_ref,
+            "Select reference emission line for <b>Quantitative Normalization</b>.",
+        )
         set_tooltip(self.combo_color_scheme, "Select <b>color scheme</b>")
         set_tooltip(
             self.combo_linear_log,

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -617,6 +617,12 @@ class GlobalProcessingClasses:
     def set_maps_quant_norm_enabled(self, enable):
         self.img_model_adv.enable_quantitative_normalization(enable)
 
+    def get_maps_quant_ref_eline(self):
+        return self.img_model_adv.quantitative_ref_eline
+
+    def set_maps_quant_ref_eline(self, ref_eline):
+        self.img_model_adv.set_quantitative_ref_eline(ref_eline)
+
     def get_maps_scale_opt(self):
         """Returns selected plot type: `Linear` or `Log`"""
         return self.img_model_adv.scale_opt
@@ -819,6 +825,12 @@ class GlobalProcessingClasses:
     def set_rgb_maps_quant_norm_enabled(self, enable):
         self.img_model_rgb.enable_quantitative_normalization(enable)
 
+    def get_rgb_maps_quant_ref_eline(self):
+        return self.img_model_rgb.quantitative_ref_eline
+
+    def set_rgb_maps_quant_ref_eline(self, ref_eline):
+        self.img_model_rgb.set_quantitative_ref_eline(ref_eline)
+
     def compute_rgb_map_ranges(self):
         self.img_model_rgb.set_low_high_value()
 
@@ -831,6 +843,9 @@ class GlobalProcessingClasses:
     #      to loading and management of quantitative calibration data
     def load_quantitative_calibration_data(self, file_path):
         self.img_model_adv.load_quantitative_calibration_data(file_path)
+
+    def get_quant_calibration_active_lines(self):
+        return self.img_model_adv.param_quant_analysis.get_active_emission_lines()
 
     def get_quant_calibration_data(self):
         return self.img_model_adv.param_quant_analysis.calibration_data

--- a/pyxrf/gui_support/gpc_class.py
+++ b/pyxrf/gui_support/gpc_class.py
@@ -1902,6 +1902,8 @@ class GlobalProcessingClasses:
         scalers, scaler_sel = self.get_maps_scaler_list()
         interpolate_on = self.get_maps_grid_interpolate()
         quant_norm_on = self.get_maps_quant_norm_enabled()
+        quant_ref_eline = self.get_maps_quant_ref_eline()
+        quant_ref_eline_list = self.get_quant_calibration_active_lines()
 
         return {
             "dset_list": dataset_list,
@@ -1910,10 +1912,20 @@ class GlobalProcessingClasses:
             "scaler_sel": scaler_sel,
             "interpolate_on": interpolate_on,
             "quant_norm_on": quant_norm_on,
+            "quant_ref_eline": quant_ref_eline,
+            "quant_ref_eline_list": quant_ref_eline_list,
         }
 
     def export_xrf_maps(
-        self, *, results_path, dataset_name, scaler_name, interpolate_on, quant_norm_on, file_formats
+        self,
+        *,
+        results_path,
+        dataset_name,
+        scaler_name,
+        interpolate_on,
+        quant_norm_on,
+        quant_ref_eline,
+        file_formats,
     ):
         # We don't want to make any changes to 'param_quant_analysis' at the original location
         #   This is a temporary copy.
@@ -1928,6 +1940,7 @@ class GlobalProcessingClasses:
                 scaler_name=scaler_name,
                 interpolate_on=interpolate_on,
                 quant_norm_on=quant_norm_on,
+                quant_ref_eline=quant_ref_eline,
                 param_quant_analysis=param_quant_analysis,
                 file_format=file_format,
             )

--- a/pyxrf/model/command_tools.py
+++ b/pyxrf/model/command_tools.py
@@ -38,6 +38,7 @@ def fit_pixel_data_and_save(
     ignore_datafile_metadata=False,
     fln_quant_calib_data=None,
     quant_distance_to_sample=0,
+    quant_ref_eline="",
     method="nnls",
     pixel_bin=0,
     raise_bg=0,
@@ -86,6 +87,10 @@ def fit_pixel_data_and_save(
         distance-to-sample used in quantitative calibration. If 0, then correction for
         distance is not applied (assumed that the standard and the sample were placed
         at the same distance from the detector).
+    quant_ref_eline: str
+        Reference emission line for quantitative calibration, e.g. 'Cu_K'. Apply quantitative
+        normalization only to the lines with existing calibration data if ``quant_ref_eline=""``
+        (emtpy string, default).
     method : str, optional
         fitting method, default as nnls
     pixel_bin : int, optional
@@ -235,6 +240,7 @@ def fit_pixel_data_and_save(
                 interpolate_to_uniform_grid=interpolate_to_uniform_grid,
                 dataset_name="dataset_fit",  # Sum of all detectors: should end with '_fit'
                 quant_norm=quant_norm,
+                quant_ref_eline=quant_ref_eline,
                 param_quant_analysis=param_quant_analysis,
                 dataset_dict=dataset,
                 positions_dict=positions_dict,
@@ -252,6 +258,7 @@ def fit_pixel_data_and_save(
                 interpolate_to_uniform_grid=interpolate_to_uniform_grid,
                 dataset_name="dataset_fit",  # Sum of all detectors: should end with '_fit'
                 quant_norm=quant_norm,
+                quant_ref_eline=quant_ref_eline,
                 param_quant_analysis=param_quant_analysis,
                 dataset_dict=dataset,
                 positions_dict=positions_dict,
@@ -363,6 +370,7 @@ def fit_pixel_data_and_save(
                     interpolate_to_uniform_grid=interpolate_to_uniform_grid,
                     dataset_name=f"dataset_{det_channel_names[i]}_fit",  # ..._det1_fit, etc.
                     quant_norm=quant_norm,
+                    quant_ref_eline=quant_ref_eline,
                     param_quant_analysis=param_quant_analysis,
                     dataset_dict=dataset,
                     positions_dict=positions_dict,
@@ -380,6 +388,7 @@ def fit_pixel_data_and_save(
                     interpolate_to_uniform_grid=interpolate_to_uniform_grid,
                     dataset_name=f"dataset_{det_channel_names[i]}_fit",  # ..._det1_fit, etc.
                     quant_norm=quant_norm,
+                    quant_ref_eline=quant_ref_eline,
                     param_quant_analysis=param_quant_analysis,
                     dataset_dict=dataset,
                     positions_dict=positions_dict,
@@ -407,6 +416,7 @@ def pyxrf_batch(
     ignore_datafile_metadata=False,
     fln_quant_calib_data=None,
     quant_distance_to_sample=0,
+    quant_ref_eline="",
     use_snip=True,
     save_txt=False,
     save_tiff=True,
@@ -463,6 +473,10 @@ def pyxrf_batch(
         distance-to-sample used in quantitative calibration. If 0, then correction for
         distance is not applied (assumed that the standard and the sample were placed
         at the same distance from the detector).
+    quant_ref_eline: str
+        Reference emission line for quantitative calibration, e.g. 'Cu_K'. Apply quantitative
+        normalization only to the lines with existing calibration data if ``quant_ref_eline=""``
+        (emtpy string, default).
     use_snip : bool, optional
         use snip method to remove background (`True`). If `False`, then do fitting
         without removing the background (runs faster)
@@ -720,6 +734,7 @@ def pyxrf_batch(
                     ignore_datafile_metadata=ignore_datafile_metadata,
                     fln_quant_calib_data=fln_quant_calib_data,
                     quant_distance_to_sample=quant_distance_to_sample,
+                    quant_ref_eline=quant_ref_eline,
                     use_snip=use_snip,
                     save_txt=save_txt,
                     save_tiff=save_tiff,

--- a/pyxrf/model/draw_image.py
+++ b/pyxrf/model/draw_image.py
@@ -102,6 +102,10 @@ class DrawImageAdvanced(Atom):
     # Variable that indicates whether quanitative normalization should be applied to data
     #   Associated with 'Quantitative' checkbox
     quantitative_normalization = Bool(False)
+    # The name of the emision line used for quantitative normalization. If "", then
+    #   quantitative normalization is applied only to the emission lines with calibration.
+    #   Assoicated with the respective combobox.
+    quantitative_ref_eline = Str()
 
     # The following fields are used for storing parameters used for quantitative analysis
     param_quant_analysis = Typed(object)
@@ -395,6 +399,25 @@ class DrawImageAdvanced(Atom):
         self.set_low_high_value()  # reset low high values based on normalization
         self.show_image()
 
+    def set_quantitative_ref_eline(self, ref_eline):
+        """
+        Set emission line used as a reference for quantitative normalization. If empty string,
+        then calibration is performed only for emission lines with existing calibration.
+        """
+        ref_eline = str(ref_eline) if (ref_eline is not None) else ""
+        if not self.param_quant_analysis.get_eline_calibration(ref_eline):
+            ref_eline = ""
+        self.quantitative_ref_eline = ref_eline
+
+        # Propagate current value of 'self.param_quant_analysis' (activate 'observer' functions)
+        # TODO: the following may not be not needed in the view of the current framework
+        tmp = self.param_quant_analysis
+        self.param_quant_analysis = ParamQuantitativeAnalysis()
+        self.param_quant_analysis = tmp
+
+        self.set_low_high_value()  # reset low high values based on normalization
+        self.show_image()
+
     def set_plot_scatter(self, is_scatter):
         self.scatter_show = is_scatter
         self.show_image()
@@ -449,6 +472,7 @@ class DrawImageAdvanced(Atom):
                     scaler_dict=self.scaler_norm_dict,
                     scaler_name_default=self.get_selected_scaler_name(),
                     data_name=data_name,
+                    ref_name=self.quantitative_ref_eline,
                     name_not_scalable=self.name_not_scalable,
                 )
             else:
@@ -620,6 +644,7 @@ class DrawImageAdvanced(Atom):
                     scaler_dict=self.scaler_norm_dict,
                     scaler_name_default=self.get_selected_scaler_name(),
                     data_name=k,
+                    ref_name=self.quantitative_ref_eline,
                     name_not_scalable=self.name_not_scalable,
                 )
             else:

--- a/pyxrf/model/draw_image_rgb.py
+++ b/pyxrf/model/draw_image_rgb.py
@@ -106,6 +106,10 @@ class DrawImageRGB(Atom):
     # Variable that indicates whether quanitative normalization should be applied to data
     #   Associated with 'Quantitative' checkbox
     quantitative_normalization = Bool(False)
+    # The name of the emision line used for quantitative normalization. If "", then
+    #   quantitative normalization is applied only to the emission lines with calibration.
+    #   Assoicated with the respective combobox.
+    quantitative_ref_eline = Str()
 
     rgb_name_list = List()  # List of names for RGB channels printed on the plot
 
@@ -287,6 +291,19 @@ class DrawImageRGB(Atom):
         self.set_low_high_value()  # reset low high values based on normalization
         self.show_image()
 
+    def set_quantitative_ref_eline(self, ref_eline):
+        """
+        Set emission line used as a reference for quantitative normalization. If empty string,
+        then calibration is performed only for emission lines with existing calibration.
+        """
+        ref_eline = str(ref_eline) if (ref_eline is not None) else ""
+        if not self.param_quant_analysis.get_eline_calibration(ref_eline):
+            ref_eline = ""
+        self.quantitative_ref_eline = ref_eline
+
+        self.set_low_high_value()  # reset low high values based on normalization
+        self.show_image()
+
     def set_low_high_value(self):
         """Set default low and high values based on normalization for each image."""
         # do not apply scaler norm on not scalable data
@@ -300,6 +317,7 @@ class DrawImageRGB(Atom):
                     scaler_dict=self.scaler_norm_dict,
                     scaler_name_default=self.get_selected_scaler_name(),
                     data_name=data_name,
+                    ref_name=self.quantitative_ref_eline,
                     name_not_scalable=self.name_not_scalable,
                 )
             else:
@@ -376,6 +394,7 @@ class DrawImageRGB(Atom):
                     scaler_dict=self.scaler_norm_dict,
                     scaler_name_default=self.get_selected_scaler_name(),
                     data_name=k,
+                    ref_name=self.quantitative_ref_eline,
                     name_not_scalable=self.name_not_scalable,
                 )
             else:

--- a/pyxrf/model/draw_image_rgb.py
+++ b/pyxrf/model/draw_image_rgb.py
@@ -297,7 +297,7 @@ class DrawImageRGB(Atom):
         then calibration is performed only for emission lines with existing calibration.
         """
         ref_eline = str(ref_eline) if (ref_eline is not None) else ""
-        if not self.param_quant_analysis.get_eline_calibration(ref_eline):
+        if not self.img_model_adv.param_quant_analysis.get_eline_calibration(ref_eline):
             ref_eline = ""
         self.quantitative_ref_eline = ref_eline
 

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -1374,6 +1374,7 @@ def output_data_to_tiff(
                     scaler_dict=fit_output,
                     scaler_name_default=None,  # We don't want data to be scaled
                     data_name=data_name,
+                    ref_name=None,
                     name_not_scalable=None,
                 )  # For simplicity, all saved maps are normalized
                 if quant_norm_applied:

--- a/pyxrf/model/fileio.py
+++ b/pyxrf/model/fileio.py
@@ -1168,6 +1168,7 @@ def output_data(
     use_average=False,
     dataset_name=None,
     quant_norm=False,
+    quant_ref_eline="",
     param_quant_analysis=None,
     positions_dict=None,
     interpolate_to_uniform_grid=False,
@@ -1198,6 +1199,11 @@ def output_data(
         should end with the suffix '_fit' (for sum of all channels), '_det1_fit" etc.
     quant_norm : bool
         True - quantitative normalization is enabled, False - disabled
+    quant_ref_eline: str
+        Reference emission line for quantitative calibration, e.g. 'Cu_K'. Apply quantitative
+        normalization only to the lines with existing calibration data if ``quant_ref_eline=""``
+        (emtpy string, default).
+
     param_quant_analysis : ParamQuantitativeAnalysis
         reference to class, which contains parameters for quantitative normalization
     interpolate_to_uniform_grid : bool
@@ -1278,6 +1284,7 @@ def output_data(
         name_append="",
         scaler_name=scaler_name,
         quant_norm=quant_norm,
+        quant_ref_eline=quant_ref_eline,
         param_quant_analysis=param_quant_analysis,
         use_average=use_average,
         scaler_name_list=scaler_name_list,
@@ -1293,6 +1300,7 @@ def output_data_to_tiff(
     scaler_name=None,
     scaler_name_list=None,
     quant_norm=False,
+    quant_ref_eline="",
     param_quant_analysis=None,
     use_average=False,
 ):
@@ -1317,6 +1325,10 @@ def output_data_to_tiff(
         The list of names of scalers that may exist in the dataset 'dataset_dict'
     quant_norm : bool
         True - apply quantitative normalization, False - use normalization by scaler
+    quant_ref_eline: str
+        Reference emission line for quantitative calibration, e.g. 'Cu_K'. Apply quantitative
+        normalization only to the lines with existing calibration data if ``quant_ref_eline=""``
+        (emtpy string, default).
     param_quant_analysis : ParamQuantitativeAnalysis
         reference to class, which contains parameters for quantitative normalization,
         if None, then quantitative normalization will be skipped
@@ -1374,7 +1386,7 @@ def output_data_to_tiff(
                     scaler_dict=fit_output,
                     scaler_name_default=None,  # We don't want data to be scaled
                     data_name=data_name,
-                    ref_name=None,
+                    ref_name=quant_ref_eline,
                     name_not_scalable=None,
                 )  # For simplicity, all saved maps are normalized
                 if quant_norm_applied:

--- a/pyxrf/model/fit_spectrum.py
+++ b/pyxrf/model/fit_spectrum.py
@@ -874,6 +874,7 @@ class Fit1D(Atom):
         scaler_name=None,
         interpolate_on=None,
         quant_norm_on=None,
+        quant_ref_eline="",
         param_quant_analysis=None,
         file_format="tiff",
     ):
@@ -892,6 +893,11 @@ class Fit1D(Atom):
             turns interpolation of images to uniform grid ON or OFF
         quant_norm_on: bool
             turns quantitative normalization of images on or off
+        quant_ref_eline: str
+            Reference emission line for quantitative calibration, e.g. 'Cu_K'. Apply quantitative
+            normalization only to the lines with existing calibration data if ``quant_ref_eline=""``
+            (emtpy string, default).
+
         param_quant_analysis: ParamQuantitativeAnalysis
             class that contains methods for quantitative normalization
         file_format: str
@@ -941,6 +947,7 @@ class Fit1D(Atom):
             interpolate_to_uniform_grid=interpolate_on,
             dataset_name=dataset_name,
             quant_norm=quant_norm_on,
+            quant_ref_eline=quant_ref_eline,
             param_quant_analysis=param_quant_analysis,
             dataset_dict=dataset_dict,
             positions_dict=positions_dict,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Changes in this PR extend functionality of quantitative analysis features. Previously, quantitative normalization of maps could be applied only to the emission lines with existing calibration. This functionality is still used as default when quantitative analysis  is enabled (`Quantitative` checkbox is checked in `XRF maps` and `RGB` tabs or in `Export to TIFF and TXT ...` dialog box). A new combo box (to the right of `Quantitative` checkbox) allows to select reference emission lines from the list of emission lines with existing calibration. The list is populated after calibration data is loaded using `Load Quantitative Calibration`. Once the reference line is selected, the adjusted quantitative calibration for the reference line is used to normalize the maps for the rest of the emission lines. The quantitative scaling factor (`rho = density/fluorescence_intensity`) for the reference line is multiplied by the atomic scaling factor `(cs2/cs1)*(A1/A2)`, where A1 and A2 represent atomic weight of the reference and target element and `cs1` and `cs2` are cross sections (in Barns) of the reference and target emission lines. The map (fluorescence_intensity) for the target element is normalized as:

```
rho2 = (cs2/cs1) * (A2/A2) * rho1
density2 = rho2 * fluorescence_intensity2
``` 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Extended functionality of quantitative analysis feature: additional combo box allows to select reference emission line from the list of emission lines with existing calibration. The calibration for the reference emission lines is used to compute quantitative normalization coefficients for all other emission lines. If the reference line is not selected, then quantitative normalization is applied only to the emission lines with existing calibration (old functionality)

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
