### PR TITLE
Compatibility with MPL 3.7.0

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -26,6 +26,24 @@ version. The instructions show how to install earlier version of ``PyQt5`` from 
     $ conda install pyxrf -c conda-forge
 
 
+.. note::
+
+  If you experience problems using `conda`, in particular if `conda` gets stuck trying to resolve
+  the environment, you may try using `mamba`, which is a more efficient drop-in replacement for
+  `conda`. Once you install *Miniconda* or *Anaconda*, install `mamba` in the base environment:
+
+  .. code:: bash
+
+    $ conda install mamba -n base -c conda-forge
+
+  Then use `mamba` instead of `conda` in all commands, for example
+
+  .. code:: bash
+
+    $ mamba create -n pyxrf-env python=3.9 pip -c conda-forge
+
+  You may still use `conda` where it works well, e.g. to activate an existing environment.
+
 1. Install `Miniconda3 <http://conda.pydata.org/miniconda.html>`_  or
    `Anaconda <https://www.anaconda.com/distribution>`_. Select the latest version.
    *Miniconda* is sufficient for running PyXRF and contains the minimum number

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -29,18 +29,22 @@ version. The instructions show how to install earlier version of ``PyQt5`` from 
 .. note::
 
   If you experience problems using `conda`, in particular if `conda` gets stuck trying to resolve
-  the environment, you may try using `mamba`, which is a more efficient drop-in replacement for
+  the environment, you may try using `mamba`, which is designed as a drop-in replacement for
   `conda`. Once you install *Miniconda* or *Anaconda*, install `mamba` in the base environment:
 
   .. code:: bash
 
     $ conda install mamba -n base -c conda-forge
 
-  Then use `mamba` instead of `conda` in all commands, for example
+  Then use `mamba` instead of `conda` in all commands. Mamba may not respect pinned versions of
+  packages. Since PyXRF currently does not work with `pyqt` v5.15, explicitly specify the version
+  `"pyqt<5.15"` during installation, for example
 
   .. code:: bash
 
     $ mamba create -n pyxrf-env python=3.9 pip -c conda-forge
+    $ mamba activate pyxrf-env
+    $ mamba install pyxrf "pyqt<5.15" -c conda-forge
 
   You may still use `conda` where it works well, e.g. to activate an existing environment.
 

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -724,7 +724,7 @@ class LinePlotModel(Atom):
 
         # Remove the plot if it exists
         if self.plot_energy_barh in self._ax.collections:
-            self._ax.collections.remove(self.plot_energy_barh)
+            self.plot_energy_barh.remove()
 
         # Create the new plot (based on new parameters if necessary
         self.plot_energy_barh = BrokenBarHCollection.span_where(
@@ -1468,7 +1468,7 @@ class LinePlotModel(Atom):
 
         # Remove the plot if it exists
         if barh_existing in axes.collections:
-            axes.collections.remove(barh_existing)
+            barh_existing.remove()
 
         # Create the new plot (based on new parameters if necessary
         barh_new = BrokenBarHCollection.span_where(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Matplotlib 3.7.0 does not support `remove` method of `ArtistList` class. The code was modified to call `remove()` methods of artists directly.


## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- PyXRF is now compatible with Matplotlib 3.7.0.

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
