### PR TITLE
HXN: load 12 scaler channels from Databroker

### DIFF
--- a/configs/hxn_pv_config.json
+++ b/configs/hxn_pv_config.json
@@ -2,7 +2,7 @@
     "beamline": "HXN",
     "xrf_detector": ["xspress3_ch1", "xspress3_ch2", "xspress3_ch3"],
     "pos_list": ["ssx[um]", "ssy[um]"],
-    "scaler_list": ["sclr1_ch1", "sclr1_ch2", "sclr1_ch3", "sclr1_ch4", "sclr1_ch5", "sclr1_ch6", "sclr1_ch7", "sclr1_ch8"],
+    "scaler_list": ["sclr1_ch1", "sclr1_ch2", "sclr1_ch3", "sclr1_ch4", "sclr1_ch5", "sclr1_ch6", "sclr1_ch7", "sclr1_ch8", "sclr1_ch9", "sclr1_ch10", "sclr1_ch11", "sclr1_ch12"],
     "other_list": ["alive", "dead", "elapsed_time", "scaler_alive"],
     "print_path": "/home/xf03id/Desktop/temp.png",
     "print_command": "lp -d HXN-printer-1 /home/xf03id/Desktop/temp.png"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

PyXRF used to load 8 scaler channels from Databroker. The number of channels was increased to 12.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

- Load 12 scaler channels from Databroker (HXN beamline).

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
