### PR TITLE
'Lazy' loading of Dask arrays from Tiled (SRX)

### DIFF
--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -10,7 +10,7 @@ import matplotlib.ticker as mticker
 import numpy as np
 from atom.api import Atom, Bool, Dict, Float, Int, List, Str, Typed, observe
 from matplotlib.axes import Axes
-from matplotlib.collections import BrokenBarHCollection
+from matplotlib.collections import PolyCollection
 from matplotlib.colors import LogNorm
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
@@ -122,7 +122,7 @@ class LinePlotModel(Atom):
     _fig_preview = Typed(Figure)
     _ax_preview = Typed(Axes)
     _lines_preview = List()
-    _bahr_preview = Typed(BrokenBarHCollection)
+    _bahr_preview = Typed(PolyCollection)
 
     plot_type_preview = Typed(PlotTypes)
     energy_range_preview = Typed(EnergyRangePresets)
@@ -177,7 +177,7 @@ class LinePlotModel(Atom):
     show_exp_opt = Bool(False)  # Flag: show spectrum preview
 
     # Reference to artist responsible for displaying the selected range of energies on the plot
-    plot_energy_barh = Typed(BrokenBarHCollection)
+    plot_energy_barh = Typed(PolyCollection)
     t_bar = Typed(object)
 
     plot_exp_list = List()
@@ -727,7 +727,7 @@ class LinePlotModel(Atom):
             self.plot_energy_barh.remove()
 
         # Create the new plot (based on new parameters if necessary
-        self.plot_energy_barh = BrokenBarHCollection.span_where(
+        self.plot_energy_barh = PolyCollection.span_where(
             x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         )
         self._ax.add_collection(self.plot_energy_barh)
@@ -1471,7 +1471,7 @@ class LinePlotModel(Atom):
             barh_existing.remove()
 
         # Create the new plot (based on new parameters if necessary
-        barh_new = BrokenBarHCollection.span_where(
+        barh_new = PolyCollection.span_where(
             x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         )
         axes.add_collection(barh_new)

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -3625,7 +3625,7 @@ def save_data_to_hdf5(
                 ns, ne = n * n_rows_batch, min((n + 1) * n_rows_batch, n_rows)
                 for retry in range(n_tiled_download_retries):
                     try:
-                        dset[ns:ne, ...] = np.array(data[ns:ne, ...])
+                        dset[ns:ne, ...] = np.nan_to_num(np.array(data[ns:ne, ...]))
                         break
                     except Exception as ex:
                         logger.error(f"Failed to load the batch: {ex}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Loading of experimental data from the Tiled server for SRX beamline. Data is loaded and saved to HDF5 file in blocks of ~40,000 pixels and allows to load large maps without excessive memory use. The procedure is efficient for loading and saving the sum of all data. It also works for loading individual channels, but is very slow.

Replaced deprecated `BrokenBarHCollection` with `PolyCollection`. PyXRF is now compatible with Matplotlib 3.9.0.

Data collected during 2D step scans still can not be loaded using Tiled.

<!--- Group the changes in the following sections: -->

### Fixed

- Compatibility with Matplotlib 3.9.0: deprecated `BrokenBarHCollection` was replaced with `PolyCollection`.

### Added

- Optimized data loaded from Tiled server for SRX beamline.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
