### PR TITLE
Fix the issue with validation of with QDoubleValidator in non-US (DE) locale

### DIFF
--- a/pyxrf/gui_module/dlg_edit_user_peak_parameters.py
+++ b/pyxrf/gui_module/dlg_edit_user_peak_parameters.py
@@ -1,9 +1,8 @@
 import logging
 
-from qtpy.QtGui import QDoubleValidator
 from qtpy.QtWidgets import QDialog, QDialogButtonBox, QGridLayout, QLabel, QVBoxLayout
 
-from .useful_widgets import LineEditExtended, LineEditReadOnly, set_tooltip
+from .useful_widgets import DoubleValidator, LineEditExtended, LineEditReadOnly, set_tooltip
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ class DialogEditUserPeakParameters(QDialog):
         self.le_fwhm = LineEditExtended()
         set_tooltip(self.le_fwhm, "<b>FWHM</b> (in keV) of the user-defined peak.")
 
-        self._validator = QDoubleValidator()
+        self._validator = DoubleValidator()
 
         vbox = QVBoxLayout()
 
@@ -99,7 +98,7 @@ class DialogEditUserPeakParameters(QDialog):
         if text is None:
             text = le_widget.text()
         valid = True
-        if self._validator.validate(text, 0)[0] != QDoubleValidator.Acceptable:
+        if self._validator.validate(text, 0)[0] != DoubleValidator.Acceptable:
             valid = False
         elif not condition(float(text)):
             valid = False

--- a/pyxrf/gui_module/dlg_find_elements.py
+++ b/pyxrf/gui_module/dlg_find_elements.py
@@ -1,9 +1,8 @@
 import copy
 
-from qtpy.QtGui import QDoubleValidator
 from qtpy.QtWidgets import QDialog, QDialogButtonBox, QGridLayout, QGroupBox, QLabel, QPushButton, QVBoxLayout
 
-from .useful_widgets import LineEditExtended, set_tooltip
+from .useful_widgets import DoubleValidator, LineEditExtended, set_tooltip
 
 
 class DialogFindElements(QDialog):
@@ -19,7 +18,7 @@ class DialogFindElements(QDialog):
         #   then simply save the changed parameter values.
         self.find_elements_requested = False
 
-        self.validator = QDoubleValidator()
+        self.validator = DoubleValidator()
 
         self.le_e_calib_a0 = LineEditExtended()
         self.le_e_calib_a0.setValidator(self.validator)
@@ -218,7 +217,7 @@ class DialogFindElements(QDialog):
         self._read_le_value(self.le_range_high, self._dialog_data["energy_bound_high"])
 
     def _validate_as_float(self, text):
-        return self.validator.validate(text, 0)[0] == QDoubleValidator.Acceptable
+        return self.validator.validate(text, 0)[0] == DoubleValidator.Acceptable
 
     def _validate_text(self, line_edit, text):
         line_edit.setValid(self._validate_as_float(text))

--- a/pyxrf/gui_module/dlg_pileup_peak_parameters.py
+++ b/pyxrf/gui_module/dlg_pileup_peak_parameters.py
@@ -1,10 +1,10 @@
 import logging
 
 from qtpy.QtCore import QRegExp
-from qtpy.QtGui import QDoubleValidator, QRegExpValidator
+from qtpy.QtGui import QRegExpValidator
 from qtpy.QtWidgets import QDialog, QDialogButtonBox, QGridLayout, QLabel, QVBoxLayout
 
-from .useful_widgets import LineEditExtended, LineEditReadOnly, set_tooltip
+from .useful_widgets import DoubleValidator, LineEditExtended, LineEditReadOnly, set_tooltip
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +117,7 @@ class DialogPileupPeakParameters(QDialog):
             text = le_widget.text()
 
         valid = True
-        if self._validator_eline.validate(text, 0)[0] != QDoubleValidator.Acceptable:
+        if self._validator_eline.validate(text, 0)[0] != DoubleValidator.Acceptable:
             valid = False
         else:
             # Try to compute energy for the pileup peak

--- a/pyxrf/gui_module/dlg_save_calibration.py
+++ b/pyxrf/gui_module/dlg_save_calibration.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QDoubleValidator
 from qtpy.QtWidgets import (
     QCheckBox,
     QDialog,
@@ -15,6 +14,7 @@ from qtpy.QtWidgets import (
 )
 
 from .useful_widgets import (
+    DoubleValidator,
     DoubleValidatorStrict,
     LineEditExtended,
     LineEditReadOnly,
@@ -176,13 +176,13 @@ class DialogSaveCalibration(QDialog):
             self.file_path = file_path
 
     def le_distance_to_sample_text_changed(self, text):
-        valid = self._le_distance_to_sample_validator.validate(text, 0)[0] == QDoubleValidator.Acceptable
+        valid = self._le_distance_to_sample_validator.validate(text, 0)[0] == DoubleValidator.Acceptable
         self.le_distance_to_sample.setValid(valid)
         self.pb_ok.setEnabled(valid)
 
     def le_distance_to_sample_editing_finished(self):
         text = self.le_distance_to_sample.text()
-        if self._le_distance_to_sample_validator.validate(text, 0)[0] == QDoubleValidator.Acceptable:
+        if self._le_distance_to_sample_validator.validate(text, 0)[0] == DoubleValidator.Acceptable:
             self.__distance_to_sample = float(text)
         self._show_distance_to_sample()
         self._show_preview()  # Show/hide warning on zero distance-to-sample value

--- a/pyxrf/gui_module/tests/test_useful_widgets.py
+++ b/pyxrf/gui_module/tests/test_useful_widgets.py
@@ -1,10 +1,10 @@
 import numpy.testing as npt
 import pytest
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import QLineEdit
 
 from pyxrf.gui_module.useful_widgets import (
+    DoubleValidator,
     DoubleValidatorRelaxed,
     IntValidatorRelaxed,
     IntValidatorStrict,
@@ -126,7 +126,8 @@ def test_IntValidatorRelaxed_2(qtbot, text, range, valid):
 ])
 # fmt: on
 def test_DoubleValidatorStrict(text, range, result):
-    validator = QDoubleValidator()
+    validator = DoubleValidator()
+
     if range is not None:
         validator.setRange(range[0], range[1], 5)
     assert validator.validate(text, 0)[0] == result, "Validation failed"

--- a/pyxrf/gui_module/useful_widgets.py
+++ b/pyxrf/gui_module/useful_widgets.py
@@ -1,6 +1,6 @@
 import logging
 
-from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtCore import QLocale, Qt, Signal, Slot
 from qtpy.QtGui import QColor, QDoubleValidator, QFontMetrics, QIntValidator, QPalette
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -423,7 +423,18 @@ class IntValidatorRelaxed(IntValidatorStrict):
         return result
 
 
-class DoubleValidatorStrict(QDoubleValidator):
+class DoubleValidator(QDoubleValidator):
+    """
+    `DoubleValidator` is identical to QDoubleValidator except that it
+    is always using 'en_US' locale.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setLocale(QLocale("en_US"))
+
+
+class DoubleValidatorStrict(DoubleValidator):
     """
     `DoubleValidatorStrict` verifies additional condition: double number can not
     contain commas, since it can't be converted to floating point number directly.

--- a/pyxrf/gui_module/wnd_load_quant_calibration.py
+++ b/pyxrf/gui_module/wnd_load_quant_calibration.py
@@ -2,7 +2,7 @@ import logging
 import textwrap
 
 from qtpy.QtCore import Qt, Signal, Slot
-from qtpy.QtGui import QBrush, QColor, QDoubleValidator
+from qtpy.QtGui import QBrush, QColor
 from qtpy.QtWidgets import (
     QButtonGroup,
     QCheckBox,
@@ -25,7 +25,7 @@ from qtpy.QtWidgets import (
 )
 
 from .dlg_view_calib_standard import DialogViewCalibStandard
-from .useful_widgets import LineEditExtended, SecondaryWindow, get_background_css, set_tooltip
+from .useful_widgets import DoubleValidator, LineEditExtended, SecondaryWindow, get_background_css, set_tooltip
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ class WndLoadQuantitativeCalibration(SecondaryWindow):
 
         self._distance_to_sample = 0.0
         self.le_distance_to_sample = LineEditExtended()
-        le_dist_validator = QDoubleValidator()
+        le_dist_validator = DoubleValidator()
         le_dist_validator.setBottom(0)
         self.le_distance_to_sample.setValidator(le_dist_validator)
         self._set_distance_to_sample()

--- a/pyxrf/gui_module/wnd_manage_emission_lines.py
+++ b/pyxrf/gui_module/wnd_manage_emission_lines.py
@@ -3,7 +3,7 @@ import logging
 
 import numpy as np
 from qtpy.QtCore import Qt, Signal, Slot
-from qtpy.QtGui import QBrush, QColor, QDoubleValidator
+from qtpy.QtGui import QBrush, QColor
 from qtpy.QtWidgets import (
     QCheckBox,
     QHBoxLayout,
@@ -21,6 +21,7 @@ from .dlg_new_user_peak import DialogNewUserPeak
 from .dlg_pileup_peak_parameters import DialogPileupPeakParameters
 from .useful_widgets import (
     CheckBoxNamed,
+    DoubleValidator,
     ElementSelection,
     LineEditExtended,
     LineEditReadOnly,
@@ -146,7 +147,7 @@ class WndManageEmissionLines(SecondaryWindow):
         """The table has only functionality necessary to demonstrate how it is going
         to look. A lot more code is needed to actually make it run."""
 
-        self._validator_peak_height = QDoubleValidator()
+        self._validator_peak_height = DoubleValidator()
         self._validator_peak_height.setBottom(0.01)
 
         self.tbl_elines = QTableWidget()
@@ -190,7 +191,7 @@ class WndManageEmissionLines(SecondaryWindow):
         self.pb_remove_rel.clicked.connect(self.pb_remove_rel_clicked)
 
         self.le_remove_rel = LineEditExtended("")
-        self._validator_le_remove_rel = QDoubleValidator()
+        self._validator_le_remove_rel = DoubleValidator()
         self._validator_le_remove_rel.setBottom(0.01)  # Some small number
         self._validator_le_remove_rel.setTop(100.0)
         self.le_remove_rel.setText(self._format_threshold(self._remove_peak_threshold))
@@ -539,7 +540,7 @@ class WndManageEmissionLines(SecondaryWindow):
             if n_col == 4:
                 text = item.text()
                 eline = self._table_contents[n_row]["eline"]
-                if self._validator_peak_height.validate(text, 0)[0] != QDoubleValidator.Acceptable:
+                if self._validator_peak_height.validate(text, 0)[0] != DoubleValidator.Acceptable:
                     val = self._table_contents[n_row]["peak_int"]
                     self._enable_events = False
                     item.setText(f"{val:.2f}")
@@ -598,7 +599,7 @@ class WndManageEmissionLines(SecondaryWindow):
 
     def le_remove_rel_editing_finished(self):
         text = self.le_remove_rel.text()
-        if self._validator_le_remove_rel.validate(text, 0)[0] == QDoubleValidator.Acceptable:
+        if self._validator_le_remove_rel.validate(text, 0)[0] == DoubleValidator.Acceptable:
             self._remove_peak_threshold = float(text)
         else:
             self.le_remove_rel.setText(self._format_threshold(self._remove_peak_threshold))
@@ -624,7 +625,7 @@ class WndManageEmissionLines(SecondaryWindow):
     def _update_le_remove_rel_state(self, text=None):
         if text is None:
             text = self.le_remove_rel.text()
-        state = self._validator_le_remove_rel.validate(text, 0)[0] == QDoubleValidator.Acceptable
+        state = self._validator_le_remove_rel.validate(text, 0)[0] == DoubleValidator.Acceptable
         self.le_remove_rel.setValid(state)
         self.pb_remove_rel.setEnabled(state)
 

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -730,6 +730,9 @@ class LinePlotModel(Atom):
         self.plot_energy_barh = PolyCollection.span_where(
             x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         )
+        # self.plot_energy_barh = self._ax.fill_between(
+        #     x_v, y1=y_min, y2=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
+        # )
         self._ax.add_collection(self.plot_energy_barh)
 
     def plot_multi_exp_data(self):
@@ -1474,6 +1477,9 @@ class LinePlotModel(Atom):
         barh_new = PolyCollection.span_where(
             x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         )
+        # barh_new = axes.fill_between(
+        #     x_v, y1=y_min, y2=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
+        # )
         axes.add_collection(barh_new)
 
         return barh_new


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`QDoubleValidator` is set to always use US locale

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Issue with failing validation of floating point values using QDoubleValidator in non-US (DE) locale.

### Added

### Changed

### Removed
