### PR TITLE
Fix deprecation

### DIFF
--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -726,16 +726,15 @@ class LinePlotModel(Atom):
         # Remove the plot if it exists
         if self.plot_energy_barh in self._ax.collections:
             self.plot_energy_barh.remove()
-            self.plot_energy_barh.remove()
 
         # Create the new plot (based on new parameters if necessary
         # self.plot_energy_barh = PolyCollection.span_where(
         #     x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         # )
+        #self._ax.add_collection(self.plot_energy_barh)
         self.plot_energy_barh = self._ax.fill_between(
             x_v, y1=y_min, y2=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         )
-        self._ax.add_collection(self.plot_energy_barh)
 
     def plot_multi_exp_data(self):
         while len(self.plot_exp_list):
@@ -1474,16 +1473,15 @@ class LinePlotModel(Atom):
         # Remove the plot if it exists
         if barh_existing in axes.collections:
             barh_existing.remove()
-            barh_existing.remove()
 
         # Create the new plot (based on new parameters if necessary
         # barh_new = PolyCollection.span_where(
         #     x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         # )
+        #axes.add_collection(barh_new)
         barh_new = axes.fill_between(
             x_v, y1=y_min, y2=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         )
-        axes.add_collection(barh_new)
 
         return barh_new
 

--- a/pyxrf/model/lineplot.py
+++ b/pyxrf/model/lineplot.py
@@ -726,14 +726,15 @@ class LinePlotModel(Atom):
         # Remove the plot if it exists
         if self.plot_energy_barh in self._ax.collections:
             self.plot_energy_barh.remove()
+            self.plot_energy_barh.remove()
 
         # Create the new plot (based on new parameters if necessary
-        self.plot_energy_barh = PolyCollection.span_where(
-            x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
-        )
-        # self.plot_energy_barh = self._ax.fill_between(
-        #     x_v, y1=y_min, y2=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
+        # self.plot_energy_barh = PolyCollection.span_where(
+        #     x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         # )
+        self.plot_energy_barh = self._ax.fill_between(
+            x_v, y1=y_min, y2=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
+        )
         self._ax.add_collection(self.plot_energy_barh)
 
     def plot_multi_exp_data(self):
@@ -1473,14 +1474,15 @@ class LinePlotModel(Atom):
         # Remove the plot if it exists
         if barh_existing in axes.collections:
             barh_existing.remove()
+            barh_existing.remove()
 
         # Create the new plot (based on new parameters if necessary
-        barh_new = PolyCollection.span_where(
-            x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
-        )
-        # barh_new = axes.fill_between(
-        #     x_v, y1=y_min, y2=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
+        # barh_new = PolyCollection.span_where(
+        #     x_v, ymin=y_min, ymax=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
         # )
+        barh_new = axes.fill_between(
+            x_v, y1=y_min, y2=y_max, where=ss, facecolor="white", edgecolor="yellow", alpha=1
+        )
         axes.add_collection(barh_new)
 
         return barh_new


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix the issue due to deprecated `PolyCollection.span_where` method. The method was replaced with `Axes.fill_between` method, which required minor changes to the code.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Deprecated `PolyCollection.span_where()` was replaced with `Axes.fill_between()` method.

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
