### PR TITLE
Fix for when snake is enabled (by default) and there is only line

### DIFF
--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -2290,6 +2290,10 @@ def map_data2D_srx_new_tiled(
     slow_step = (slow_stop - slow_start) / slow_pts
 
     snaking_enabled = bool(scan_doc["snake"])
+    if fast_pts == 1 or slow_pts == 1:
+        # There is only one row or column of data
+        # and no need to flip the data to match snaking
+        snaking_enabled = False
 
     print(f"Scan type: {scan_doc['type']}")
 


### PR DESCRIPTION
When running step scans, by default, snake is enabled. If a single row or column is collected and snake is still enabled, exporting the data will fail. This is an attempt to resolve that, by overriding the snake value.


## Description
The code checks if there is only one row or column collected in the map. If there is, then it will disable snake.

## Motivation and Context
This is required because if there is only one "row" of data, if snake is enable (default), then it will try to flip every other row which starts at row of index 1, which doesn't exist.


## Summary of Changes for Release Notes
Add check for a single line of mapping and disables snake

### Fixed

### Added

### Changed

### Removed

## How Has This Been Tested?
Tested on 1D/2D mapping data
