### PR TITLE
Additional scaler channels available for SRX

### DIFF
--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1851,6 +1851,7 @@ def map_data2D_srx_new(
         d_xs, d_xs_sum, N_xs = [], [], 0
         d_xs2, d_xs2_sum, N_xs2 = [], [], 0
         sclr_list = ["i0", "i0_time", "time", "im", "it"]
+        sclr_list += [f'i{n:02}' for n in range(5, 32 + 1)]
         sclr_dict = {}
         fast_pos, slow_pos = [], []
 
@@ -2404,6 +2405,7 @@ def map_data2D_srx_new_tiled(
             raise ValueError(f"No fluorescence data is found for the experiment {run_id_uid!r}")
 
         sclr_list = ["i0", "i0_time", "im", "it"]
+        sclr_list += [f'i{n:02}' for n in range(5, 32 + 1)]
         sclr_dict = dict()
         for k in sclr_list:
             if k in data_stream0:

--- a/pyxrf/model/load_data_from_db.py
+++ b/pyxrf/model/load_data_from_db.py
@@ -1851,7 +1851,7 @@ def map_data2D_srx_new(
         d_xs, d_xs_sum, N_xs = [], [], 0
         d_xs2, d_xs2_sum, N_xs2 = [], [], 0
         sclr_list = ["i0", "i0_time", "time", "im", "it"]
-        sclr_list += [f'i{n:02}' for n in range(5, 32 + 1)]
+        sclr_list += [f"i{n:02}" for n in range(5, 32 + 1)]
         sclr_dict = {}
         fast_pos, slow_pos = [], []
 
@@ -2405,7 +2405,7 @@ def map_data2D_srx_new_tiled(
             raise ValueError(f"No fluorescence data is found for the experiment {run_id_uid!r}")
 
         sclr_list = ["i0", "i0_time", "im", "it"]
-        sclr_list += [f'i{n:02}' for n in range(5, 32 + 1)]
+        sclr_list += [f"i{n:02}" for n in range(5, 32 + 1)]
         sclr_dict = dict()
         for k in sclr_list:
             if k in data_stream0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added lines to include extra scaler channels to SRX only if they have been acquired for a given scan.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows for extra channels beyond the normal i0, im, and it from i05 to i32 in the current implementation.

## Summary of Changes for Release Notes
Additional scaler channels available for SRX if they were included in the scan.
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenance PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->
<!--- Group the changes in the following sections: -->

### Added
Support for loading additional variable number of scaler channels at SRX

## How Has This Been Tested?
Tested on a local machine with scans acquired with a variable number of scaler channels.
Standard tests for any merge.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->